### PR TITLE
Fix sticky about section card overlap

### DIFF
--- a/script.js
+++ b/script.js
@@ -36,7 +36,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const autoAnimateGroups = [
     [".hero__stats", 120],
-    [".sticky-section__slides", 150],
+    [".sticky-section__slides", 80],
     [".project-timeline", 140],
     [".project-detail__main", 140],
     [".project-sidebar", 160],

--- a/styles.css
+++ b/styles.css
@@ -163,10 +163,10 @@ body::before {
 }
 
 [data-animate="panel"] {
-  --animate-translate-y: 110px;
-  --animate-rotate-x: 18deg;
-  --animate-scale: 0.92;
-  --animate-blur: 12px;
+  --animate-translate-y: clamp(28px, 3.8vw, 48px);
+  --animate-rotate-x: 12deg;
+  --animate-scale: 0.94;
+  --animate-blur: 10px;
   transform-origin: top center;
 }
 
@@ -893,6 +893,8 @@ body::before {
   flex-direction: column;
   gap: clamp(2.5rem, 5vw, 3.75rem);
   padding-block: 0.6rem 4rem;
+  perspective: 1200px;
+  perspective-origin: top;
 }
 
 .sticky-card {


### PR DESCRIPTION
## Summary
- reduce the initial panel animation depth so about section cards no longer overlap while waiting to animate
- give the sticky card column perspective and speed up its reveal staggering for a smoother entrance

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e185361b188327b635f3f78aeab37e