### PR TITLE
Rebuild about section with sticky timeline layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,19 +144,23 @@
               以下以黏著式敘事整理我的背景、研究、獲獎與帶隊經驗。
             </p>
           </div>
-          <div class="sticky-section" data-sticky-section>
-            <div class="sticky-section__pin" data-animate="fade-up">
-              <span class="sticky-section__label">Profile</span>
-              <h3 class="sticky-section__title">跨越地球科學與資訊工程的產品創造者</h3>
-              <p class="sticky-section__description">
+          <div class="about-sticky" data-about-sticky>
+            <div class="about-sticky__intro" data-animate="fade-up">
+              <span class="about-sticky__label">Profile</span>
+              <h3 class="about-sticky__title">跨越地球科學與資訊工程的產品創造者</h3>
+              <p class="about-sticky__description">
                 我在國立臺灣師範大學主修地球科學並雙主修資訊工程，
                 從專題研究、資料分析到互動產品開發一路親自實作。外向實事求是的個性讓我
                 擅長協調跨領域團隊，把複雜需求拆解成可以驗證的成果。
               </p>
-              <dl class="sticky-section__facts">
+              <dl class="about-sticky__facts">
                 <div>
                   <dt>教育</dt>
                   <dd>國立臺灣師範大學 地球科學系<br />雙主修資訊工程（2021.09 – 現在）</dd>
+                </div>
+                <div>
+                  <dt>研究領域</dt>
+                  <dd>資料分析、ML 模型壓縮、沉浸式互動系統、跨裝置體驗設計</dd>
                 </div>
                 <div>
                   <dt>外語能力</dt>
@@ -164,80 +168,145 @@
                 </div>
               </dl>
             </div>
-            <div class="sticky-section__slides" data-animate-group data-animate-interval="160">
-              <article class="sticky-card" data-animate="panel" data-parallax-depth="0.05">
-                <span class="sticky-card__icon" aria-hidden="true">🌱</span>
-                <div class="sticky-card__content">
-                  <h3>個人簡介</h3>
-                  <p>
-                    我熱愛把研究成果轉化為實際應用，自大二起持續投入跨領域專題。開朗外向且善於表達，
-                    喜歡帶著團隊一起把想法落實，確保每一步都有數據與故事支撐。
-                  </p>
+            <div class="about-sticky__body">
+              <div class="about-sticky__pin" aria-live="polite">
+                <div class="about-sticky__panels">
+                  <article class="about-panel is-active" data-about-panel="profile" aria-hidden="false">
+                    <header>
+                      <h3>個人簡介</h3>
+                      <p>
+                        我熱愛把研究成果轉化為實際應用，自大二起持續投入跨領域專題。開朗外向且善於表達，
+                        喜歡帶著團隊一起把想法落實，確保每一步都有數據與故事支撐。
+                      </p>
+                    </header>
+                  </article>
+                  <article class="about-panel" data-about-panel="research" aria-hidden="true">
+                    <header>
+                      <h3>專題研究</h3>
+                    </header>
+                    <ul class="about-panel__list">
+                      <li>
+                        <strong>颱風對海洋表層葉綠素 a 影響之研究｜2018.09 – 2021.10</strong><br />
+                        以 MATLAB 分析西北太平洋颱風對藻類數量的影響，獲「美國氣象學會獎」。
+                      </li>
+                      <li>
+                        <strong>Model Selection: Trade-Offs Between Model Size and Predictive Accuracy｜2023.10 – 2024.01</strong><br />
+                        探討模型大小與準確率的平衡，透過超參數調整提升小型模型表現。
+                      </li>
+                    </ul>
+                  </article>
+                  <article class="about-panel" data-about-panel="awards" aria-hidden="true">
+                    <header>
+                      <h3>競賽與獲獎</h3>
+                    </header>
+                    <ul class="about-panel__list">
+                      <li>OpenHCI 2024 人機互動工作坊 <strong>最佳 Demo 獎</strong>（ME_NU 菜單推薦系統）。</li>
+                      <li>Normal Game Jam 2024 <strong>Gameplay 第一名、Overall 第三名</strong>（Show the Sheep）。</li>
+                      <li>師大地科五育獎學金連續 <strong>5</strong> 次獲獎（2022.01 – 2023.09）。</li>
+                    </ul>
+                  </article>
+                  <article class="about-panel" data-about-panel="experience" aria-hidden="true">
+                    <header>
+                      <h3>工作經驗</h3>
+                    </header>
+                    <ul class="about-panel__list">
+                      <li>國立臺灣師範大學智慧運算導向永續發展研究中心 網頁維護總負責人（2023.09 – 現在）。</li>
+                      <li>國立臺灣師範大學地球科學系 網頁維護總負責人（2023.02 – 現在）。</li>
+                      <li>攜曦程式推廣學會 Python 課程助教（2021.09 – 2021.12）。</li>
+                    </ul>
+                  </article>
+                  <article class="about-panel" data-about-panel="projects" aria-hidden="true">
+                    <header>
+                      <h3>專案亮點</h3>
+                    </header>
+                    <ul class="about-panel__list">
+                      <li>動態背光調光系統自行設計硬體與韌體，將成本降至市售方案的 10%。</li>
+                      <li>Your Sky Pylot 平台整合多來源資料並提供互動儀表，讓使用者快速掌握觀星條件。</li>
+                    </ul>
+                  </article>
+                  <article class="about-panel" data-about-panel="leadership" aria-hidden="true">
+                    <header>
+                      <h3>社團與領導</h3>
+                    </header>
+                    <ul class="about-panel__list">
+                      <li>國立臺灣大學慈幼山地服務團利稻家 帶隊總召（2021.09 – 2021.12），領導 30 人籌辦 9 天營隊。</li>
+                      <li>師大地科展 2023 總召（2021.09 – 2021.12），與 Open House 合作規劃科普活動。</li>
+                    </ul>
+                  </article>
                 </div>
-              </article>
-              <article class="sticky-card" data-animate="panel" data-parallax-depth="0.046">
-                <span class="sticky-card__icon" aria-hidden="true">🔬</span>
-                <div class="sticky-card__content">
-                  <h3>專題研究</h3>
-                  <ul class="sticky-card__list">
-                    <li>
-                      <strong>颱風對海洋表層葉綠素 a 影響之研究｜2018.09 – 2021.10</strong><br />
-                      以 MATLAB 分析西北太平洋颱風對藻類數量的影響，獲「美國氣象學會獎」。
-                    </li>
-                    <li>
-                      <strong>Model Selection: Trade-Offs Between Model Size and Predictive Accuracy｜2023.10 – 2024.01</strong><br />
-                      探討模型大小與準確率的平衡，透過超參數調整提升小型模型表現。
-                    </li>
-                  </ul>
+                <div class="about-sticky__media">
+                  <div class="about-media__item is-active" data-about-media="profile" aria-hidden="false">
+                    <span class="about-media__icon" aria-hidden="true">🌱</span>
+                    <p class="about-media__caption">跨領域養成，轉化研究成產品故事</p>
+                  </div>
+                  <div class="about-media__item" data-about-media="research" aria-hidden="true">
+                    <span class="about-media__icon" aria-hidden="true">🔬</span>
+                    <p class="about-media__caption">以資料分析與模型調校累積研究底蘊</p>
+                  </div>
+                  <div class="about-media__item" data-about-media="awards" aria-hidden="true">
+                    <span class="about-media__icon" aria-hidden="true">🏅</span>
+                    <p class="about-media__caption">競賽肯定帶來快速驗證與迭代能力</p>
+                  </div>
+                  <div class="about-media__item" data-about-media="experience" aria-hidden="true">
+                    <span class="about-media__icon" aria-hidden="true">💼</span>
+                    <p class="about-media__caption">維運組織網站與跨部門協作的實戰經驗</p>
+                  </div>
+                  <div class="about-media__item" data-about-media="projects" aria-hidden="true">
+                    <span class="about-media__icon" aria-hidden="true">🛠️</span>
+                    <p class="about-media__caption">從硬體到平台的 MVP 交付與迭代</p>
+                  </div>
+                  <div class="about-media__item" data-about-media="leadership" aria-hidden="true">
+                    <span class="about-media__icon" aria-hidden="true">🤝</span>
+                    <p class="about-media__caption">領導大型活動，培養共創與溝通能力</p>
+                  </div>
                 </div>
-              </article>
-              <article class="sticky-card" data-animate="panel" data-parallax-depth="0.042">
-                <span class="sticky-card__icon" aria-hidden="true">🏅</span>
-                <div class="sticky-card__content">
-                  <h3>競賽與獲獎</h3>
-                  <ul class="sticky-card__list">
-                    <li>OpenHCI 2024 人機互動工作坊 <strong>最佳 Demo 獎</strong>（ME_NU 菜單推薦系統）。</li>
-                    <li>Normal Game Jam 2024 <strong>Gameplay 第一名、Overall 第三名</strong>（Show the Sheep）。</li>
-                    <li>師大地科五育獎學金連續 <strong>5</strong> 次獲獎（2022.01 – 2023.09）。</li>
-                  </ul>
-                </div>
-              </article>
-              <article class="sticky-card" data-animate="panel" data-parallax-depth="0.038">
-                <span class="sticky-card__icon" aria-hidden="true">💼</span>
-                <div class="sticky-card__content">
-                  <h3>工作經驗</h3>
-                  <ul class="sticky-card__list">
-                    <li>國立臺灣師範大學智慧運算導向永續發展研究中心 網頁維護總負責人（2023.09 – 現在）。</li>
-                    <li>國立臺灣師範大學地球科學系 網頁維護總負責人（2023.02 – 現在）。</li>
-                    <li>攜曦程式推廣學會 Python 課程助教（2021.09 – 2021.12）。</li>
-                  </ul>
-                </div>
-              </article>
-              <article class="sticky-card" data-animate="panel" data-parallax-depth="0.034">
-                <span class="sticky-card__icon" aria-hidden="true">🛠️</span>
-                <div class="sticky-card__content">
-                  <h3>專案亮點</h3>
-                  <ul class="sticky-card__list">
-                    <li>動態背光調光系統自行設計硬體與韌體，將成本降至市售方案的 10%。</li>
-                    <li>Your Sky Pylot 平台整合多來源資料並提供互動儀表，讓使用者快速掌握觀星條件。</li>
-                  </ul>
-                </div>
-              </article>
-              <article class="sticky-card" data-animate="panel" data-parallax-depth="0.03">
-                <span class="sticky-card__icon" aria-hidden="true">🤝</span>
-                <div class="sticky-card__content">
-                  <h3>社團與領導</h3>
-                  <ul class="sticky-card__list">
-                    <li>國立臺灣大學慈幼山地服務團利稻家 帶隊總召（2021.09 – 2021.12），領導 30 人籌辦 9 天營隊。</li>
-                    <li>師大地科展 2023 總召（2021.09 – 2021.12），與 Open House 合作規劃科普活動。</li>
-                  </ul>
-                </div>
-              </article>
+              </div>
+              <div class="about-sticky__timeline" data-animate-group data-animate-interval="160">
+                <article class="about-stage is-active" data-about-stage="profile" data-animate="fade-up">
+                  <span class="about-stage__number">01</span>
+                  <div class="about-stage__content">
+                    <h3>跨域養成</h3>
+                    <p>地科與資工並進，擅長用故事與數據連結跨領域團隊。</p>
+                  </div>
+                </article>
+                <article class="about-stage" data-about-stage="research" data-animate="fade-up">
+                  <span class="about-stage__number">02</span>
+                  <div class="about-stage__content">
+                    <h3>研究實力</h3>
+                    <p>從衛星資料分析到模型調校，持續打磨資料與 AI 能力。</p>
+                  </div>
+                </article>
+                <article class="about-stage" data-about-stage="awards" data-animate="fade-up">
+                  <span class="about-stage__number">03</span>
+                  <div class="about-stage__content">
+                    <h3>競賽成果</h3>
+                    <p>多次獲獎驗證創新實力，也把使用者回饋導入下一版。</p>
+                  </div>
+                </article>
+                <article class="about-stage" data-about-stage="experience" data-animate="fade-up">
+                  <span class="about-stage__number">04</span>
+                  <div class="about-stage__content">
+                    <h3>實務經驗</h3>
+                    <p>長期維運校內大型網站，與跨單位協作完成上線。</p>
+                  </div>
+                </article>
+                <article class="about-stage" data-about-stage="projects" data-animate="fade-up">
+                  <span class="about-stage__number">05</span>
+                  <div class="about-stage__content">
+                    <h3>專案亮點</h3>
+                    <p>打造硬軟整合產品與資料平台，著重體驗與可行性。</p>
+                  </div>
+                </article>
+                <article class="about-stage" data-about-stage="leadership" data-animate="fade-up">
+                  <span class="about-stage__number">06</span>
+                  <div class="about-stage__content">
+                    <h3>領導協作</h3>
+                    <p>策畫營隊與科普活動，訓練決策、溝通與臨場應變。</p>
+                  </div>
+                </article>
+              </div>
             </div>
           </div>
-        </div>
-      </section>
-
       <section
         class="section section--layered"
         id="projects"

--- a/script.js
+++ b/script.js
@@ -14,7 +14,6 @@ document.addEventListener("DOMContentLoaded", () => {
     [".stat-card", "scale"],
     [".intro__highlights li", "scale"],
     [".section__header", "fade-up"],
-    [".sticky-card", "panel"],
     [".filter-controls", "fade-up"],
     [".project-card", "tilt"],
     [".contact__actions", "fade-up"],
@@ -36,7 +35,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const autoAnimateGroups = [
     [".hero__stats", 120],
-    [".sticky-section__slides", 150],
+    [".about-sticky__timeline", 160],
     [".project-timeline", 140],
     [".project-detail__main", 140],
     [".project-sidebar", 160],
@@ -222,6 +221,81 @@ document.addEventListener("DOMContentLoaded", () => {
       prefersReducedMotion.addListener(handleParallaxPreference);
     }
   }
+
+  const aboutStickyLayouts = document.querySelectorAll("[data-about-sticky]");
+
+  aboutStickyLayouts.forEach((layout) => {
+    const stages = Array.from(layout.querySelectorAll("[data-about-stage]"));
+    const panels = Array.from(layout.querySelectorAll("[data-about-panel]"));
+    const mediaItems = Array.from(layout.querySelectorAll("[data-about-media]"));
+
+    if (!stages.length || !panels.length) {
+      return;
+    }
+
+    let activeId = "";
+
+    const setActiveStage = (id) => {
+      panels.forEach((panel) => {
+        const isMatch = panel.dataset.aboutPanel === id;
+        panel.classList.toggle("is-active", isMatch);
+        panel.setAttribute("aria-hidden", (!isMatch).toString());
+      });
+
+      mediaItems.forEach((item) => {
+        const isMatch = item.dataset.aboutMedia === id;
+        item.classList.toggle("is-active", isMatch);
+        item.setAttribute("aria-hidden", (!isMatch).toString());
+      });
+
+      stages.forEach((stage) => {
+        stage.classList.toggle("is-active", stage.dataset.aboutStage === id);
+      });
+    };
+
+    const updateActiveStage = () => {
+      const viewportHeight = window.innerHeight || 1;
+      const focusLine = viewportHeight * 0.45;
+      let closestStage = stages[0];
+      let smallestDistance = Number.POSITIVE_INFINITY;
+
+      stages.forEach((stage) => {
+        const rect = stage.getBoundingClientRect();
+        const midpoint = rect.top + rect.height / 2;
+        const distance = Math.abs(midpoint - focusLine);
+        if (distance < smallestDistance) {
+          smallestDistance = distance;
+          closestStage = stage;
+        }
+      });
+
+      if (!closestStage) {
+        return;
+      }
+
+      const nextId = closestStage.dataset.aboutStage || "";
+      if (nextId && nextId !== activeId) {
+        activeId = nextId;
+        setActiveStage(activeId);
+      }
+    };
+
+    let ticking = false;
+    const requestUpdate = () => {
+      if (ticking) {
+        return;
+      }
+      ticking = true;
+      requestAnimationFrame(() => {
+        ticking = false;
+        updateActiveStage();
+      });
+    };
+
+    updateActiveStage();
+    window.addEventListener("scroll", requestUpdate, { passive: true });
+    window.addEventListener("resize", requestUpdate);
+  });
 
   const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
   const storedTheme = localStorage.getItem("patrick-theme");

--- a/styles.css
+++ b/styles.css
@@ -163,10 +163,10 @@ body::before {
 }
 
 [data-animate="panel"] {
-  --animate-translate-y: 110px;
-  --animate-rotate-x: 18deg;
-  --animate-scale: 0.92;
-  --animate-blur: 12px;
+  --animate-translate-y: clamp(28px, 3.8vw, 48px);
+  --animate-rotate-x: 12deg;
+  --animate-scale: 0.94;
+  --animate-blur: 10px;
   transform-origin: top center;
 }
 
@@ -806,18 +806,16 @@ body::before {
 }
 
 .section--sticky {
-  padding-block: 8rem;
+  padding-block: clamp(6rem, 5vw + 4rem, 8rem);
 }
 
-.sticky-section {
+.about-sticky {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
-  gap: clamp(2rem, 6vw, 5rem);
-  align-items: start;
+  gap: clamp(3rem, 5vw, 4.8rem);
 }
 
-.sticky-section::before {
+.about-sticky::before {
   content: "";
   position: absolute;
   inset: -8%;
@@ -829,18 +827,19 @@ body::before {
   z-index: -1;
 }
 
-.sticky-section__pin {
-  position: sticky;
-  top: 8.5rem;
-  padding: 2.2rem 2.5rem;
-  border-radius: 1.8rem;
-  background: color-mix(in srgb, var(--color-surface-strong) 85%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+.about-sticky__intro {
+  position: relative;
+  padding: clamp(2rem, 2vw + 1.6rem, 2.75rem) clamp(2.2rem, 3vw, 3rem);
+  border-radius: 1.9rem;
+  background: color-mix(in srgb, var(--color-surface-strong) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
   box-shadow: 0 32px 70px rgba(15, 23, 42, 0.18);
   backdrop-filter: blur(28px);
+  display: grid;
+  gap: 1.3rem;
 }
 
-.sticky-section__label {
+.about-sticky__label {
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
@@ -853,188 +852,276 @@ body::before {
   text-transform: uppercase;
 }
 
-.sticky-section__title {
-  margin: 1.4rem 0 1rem;
-  font-size: clamp(1.75rem, 1.6rem + 1vw, 2.35rem);
+.about-sticky__title {
+  margin: 0;
+  font-size: clamp(1.9rem, 1.5rem + 1.4vw, 2.45rem);
 }
 
-.sticky-section__description {
+.about-sticky__description {
   margin: 0;
   color: var(--color-muted);
   line-height: 1.8;
 }
 
-.sticky-section__facts {
-  margin: 1.8rem 0 0;
+.about-sticky__facts {
+  margin: 0;
   display: grid;
   gap: 1.2rem;
 }
 
-.sticky-section__facts div {
+.about-sticky__facts div {
   display: grid;
-  gap: 0.35rem;
+  gap: 0.4rem;
 }
 
-.sticky-section__facts dt {
+.about-sticky__facts dt {
   font-size: 0.82rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: color-mix(in srgb, var(--color-muted) 65%, transparent);
 }
 
-.sticky-section__facts dd {
+.about-sticky__facts dd {
   margin: 0;
   color: color-mix(in srgb, var(--color-text) 92%, transparent);
-  line-height: 1.6;
+  line-height: 1.65;
 }
 
-.sticky-section__slides {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(2.5rem, 5vw, 3.75rem);
-  padding-block: 0.6rem 4rem;
-}
-
-.sticky-card {
-  position: relative;
+.about-sticky__body {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 1.6rem;
-  padding: clamp(1.8rem, 1.5rem + 1vw, 2.4rem);
-  border-radius: 1.7rem;
-  background: linear-gradient(160deg, color-mix(in srgb, var(--color-surface-strong) 95%, transparent),
-      color-mix(in srgb, var(--color-primary) 20%, transparent));
-  border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
-  box-shadow: 0 26px 60px rgba(15, 23, 42, 0.2);
-  overflow: hidden;
-  transform-style: preserve-3d;
+  grid-template-columns: minmax(0, 420px) minmax(0, 1fr);
+  gap: clamp(2.8rem, 6vw, 5.4rem);
+  align-items: start;
 }
 
-.sticky-card::before {
-  content: "";
-  position: absolute;
-  inset: -1px;
-  border-radius: inherit;
-  background: radial-gradient(circle at top right, rgba(129, 140, 248, 0.45), transparent 62%);
-  opacity: 0.45;
-  transition: opacity var(--transition);
-  pointer-events: none;
+.about-sticky__pin {
+  position: sticky;
+  top: clamp(5.6rem, 6vw, 8rem);
+  display: grid;
+  gap: clamp(1.6rem, 2.2vw, 2.6rem);
+  align-self: start;
 }
 
-.sticky-card::after {
-  content: "";
+.about-sticky__panels {
+  position: relative;
+  min-height: clamp(260px, 34vw, 380px);
+}
+
+.about-panel {
   position: absolute;
   inset: 0;
-  border-radius: inherit;
-  background: linear-gradient(140deg, rgba(56, 189, 248, 0.18), transparent 65%);
+  display: grid;
+  gap: 1.1rem;
+  padding: 0 0.3rem;
   opacity: 0;
-  transition: opacity var(--transition);
+  transform: translateY(30px);
+  transition: opacity var(--transition), transform var(--transition);
   pointer-events: none;
 }
 
-.sticky-card__icon {
-  display: grid;
-  place-items: center;
-  width: clamp(3.6rem, 3rem + 1.5vw, 4.1rem);
-  height: clamp(3.6rem, 3rem + 1.5vw, 4.1rem);
-  border-radius: 1.2rem;
-  background: linear-gradient(145deg, rgba(79, 70, 229, 0.9), rgba(236, 72, 153, 0.78));
-  color: #fff;
-  font-size: clamp(1.65rem, 1.4rem + 0.6vw, 1.95rem);
-  box-shadow: 0 18px 38px rgba(79, 70, 229, 0.35);
-  transform: translateZ(40px);
+.about-panel.is-active {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
 }
 
-.sticky-card__content h3 {
-  margin: 0;
-  font-size: 1.35rem;
-}
-
-.sticky-card__content p {
-  margin: 0.85rem 0 1.3rem;
-  color: var(--color-muted);
-  line-height: 1.8;
-}
-
-.sticky-card__list {
+.about-panel__list {
   margin: 0;
   padding-left: 1.2rem;
   display: grid;
-  gap: 0.55rem;
+  gap: 0.65rem;
   color: color-mix(in srgb, var(--color-text) 94%, transparent);
-  line-height: 1.7;
+  line-height: 1.75;
 }
 
-.sticky-card__list strong {
+.about-panel__list strong {
   color: var(--color-primary);
   font-weight: 700;
 }
 
-.sticky-card__tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
+.about-sticky__media {
+  position: relative;
+  min-height: clamp(240px, 34vw, 360px);
+  border-radius: 1.9rem;
+  background: linear-gradient(160deg, color-mix(in srgb, var(--color-surface-strong) 95%, transparent),
+      color-mix(in srgb, var(--color-primary) 18%, transparent));
+  border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+  overflow: hidden;
+  box-shadow: 0 26px 60px rgba(15, 23, 42, 0.2);
+}
+
+.about-media__item {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 1.1rem;
+  padding: clamp(2rem, 3vw, 2.8rem);
+  opacity: 0;
+  transform: translateY(40px) scale(0.96);
+  transition: opacity var(--transition), transform var(--transition);
+  color: color-mix(in srgb, var(--color-text) 96%, transparent);
+}
+
+.about-media__item.is-active {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.about-media__icon {
+  display: grid;
+  place-items: center;
+  width: clamp(3.8rem, 3.2rem + 1.8vw, 4.4rem);
+  height: clamp(3.8rem, 3.2rem + 1.8vw, 4.4rem);
+  border-radius: 1.3rem;
+  background: linear-gradient(145deg, rgba(79, 70, 229, 0.9), rgba(236, 72, 153, 0.78));
+  font-size: clamp(1.8rem, 1.5rem + 0.8vw, 2.2rem);
+  color: #fff;
+  box-shadow: 0 18px 38px rgba(79, 70, 229, 0.32);
+}
+
+.about-media__caption {
   margin: 0;
-  padding: 0;
-  list-style: none;
+  max-width: 18ch;
+  text-align: center;
+  line-height: 1.6;
 }
 
-.sticky-card__tags li {
-  padding: 0.4rem 0.85rem;
-  border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
-  background: color-mix(in srgb, var(--color-surface-strong) 80%, transparent);
-  font-size: 0.82rem;
-  letter-spacing: 0.02em;
+.about-sticky__timeline {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(3.2rem, 6vw, 6.6rem);
+  padding-block: 1.5rem clamp(7.5rem, 12vw, 10rem);
 }
 
-.sticky-card:hover::after,
-.sticky-card:focus-within::after {
-  opacity: 0.75;
+.about-sticky__timeline::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: clamp(1.4rem, 2vw, 2.1rem);
+  width: 2px;
+  background: color-mix(in srgb, var(--color-border) 70%, transparent);
 }
 
-.sticky-card:hover {
-  transform: translateY(-6px) rotateX(6deg);
-  box-shadow: 0 36px 80px rgba(15, 23, 42, 0.32);
+.about-stage {
+  position: relative;
+  min-height: clamp(62vh, 50vh + 12vw, 92vh);
+  padding-left: clamp(3.5rem, 3vw + 2.6rem, 4.6rem);
+  display: grid;
+  align-content: center;
+  gap: 0.9rem;
+  color: color-mix(in srgb, var(--color-muted) 80%, transparent);
 }
 
-.sticky-card:focus-within {
-  outline: 2px solid color-mix(in srgb, var(--color-primary) 55%, transparent);
-  outline-offset: 4px;
+.about-stage::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: clamp(1.2rem, 2vw, 1.9rem);
+  width: 2px;
+  height: 100%;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-primary) 45%, transparent), transparent 82%);
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.about-stage.is-active::before {
+  opacity: 1;
+}
+
+.about-stage.is-active {
+  color: color-mix(in srgb, var(--color-text) 92%, transparent);
+}
+
+.about-stage__number {
+  position: absolute;
+  top: 1.1rem;
+  left: 0;
+  transform: translateX(-50%);
+  font-size: 1.2rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-muted) 60%, transparent);
+}
+
+.about-stage.is-active .about-stage__number {
+  color: var(--color-primary);
+}
+
+.about-stage__content h3 {
+  margin: 0;
+  font-size: clamp(1.35rem, 1.15rem + 0.8vw, 1.8rem);
+}
+
+.about-stage__content p {
+  margin: 0;
+  max-width: 34ch;
+  line-height: 1.7;
 }
 
 @media (max-width: 1024px) {
-  .sticky-section {
+  .about-sticky__body {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .sticky-section__pin {
+  .about-sticky__pin {
     position: static;
-    margin-bottom: 2.4rem;
   }
 
-  .sticky-card {
-    grid-template-columns: minmax(0, 1fr);
+  .about-sticky__timeline::before {
+    left: 1rem;
+  }
+
+  .about-stage {
+    padding-left: 3.4rem;
   }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 720px) {
   .section--sticky {
-    padding-block: 5.5rem;
+    padding-block: 5.2rem;
   }
 
-  .sticky-section__pin {
-    padding: 1.6rem;
+  .about-sticky {
+    gap: 2.4rem;
   }
 
-  .sticky-card {
-    padding: 1.6rem;
+  .about-sticky__intro {
+    padding: 1.6rem 1.9rem;
   }
 
-  .sticky-card__tags li {
-    font-size: 0.76rem;
+  .about-sticky__timeline {
+    padding-block: 1rem 6rem;
+  }
+
+  .about-stage {
+    min-height: clamp(70vh, 55vh + 10vw, 86vh);
+  }
+
+  .about-sticky__media {
+    min-height: clamp(220px, 60vw, 320px);
   }
 }
+
+@media (max-width: 560px) {
+  .about-stage {
+    min-height: 60vh;
+    padding-left: 2.6rem;
+  }
+
+  .about-stage__number {
+    font-size: 1rem;
+  }
+
+  .about-sticky__timeline::before {
+    left: 0.85rem;
+  }
+}
+
 
 .filter-controls {
   display: flex;


### PR DESCRIPTION
## Summary
- replace the "關於我" section markup with a new sticky timeline layout that pairs pinned panels with a dynamic media column
- rewrite the supporting styles to drive the new layout, gradients, and responsive breakpoints for the about timeline
- add scroll logic to synchronize visible panels and media with the currently focused timeline stage during scroll

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e185361b188327b635f3f78aeab37e