### PR TITLE
Swap about section layout and adjust card sizing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -893,12 +893,14 @@ body::before {
 
 .about-sticky__body {
   display: grid;
-  grid-template-columns: minmax(0, 420px) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 420px);
+  grid-template-areas: "timeline pin";
   gap: clamp(2.8rem, 6vw, 5.4rem);
   align-items: start;
 }
 
 .about-sticky__pin {
+  grid-area: pin;
   position: sticky;
   top: clamp(5.6rem, 6vw, 8rem);
   display: grid;
@@ -908,7 +910,7 @@ body::before {
 
 .about-sticky__panels {
   position: relative;
-  min-height: clamp(240px, 28vw, 340px);
+  min-height: clamp(200px, 24vw, 300px);
 }
 
 .about-panel {
@@ -957,7 +959,7 @@ body::before {
 
 .about-sticky__media {
   position: relative;
-  min-height: clamp(240px, 28vw, 340px);
+  min-height: clamp(200px, 24vw, 300px);
   margin-bottom: 0.5rem;
   border-radius: 1.9rem;
   background: linear-gradient(160deg, color-mix(in srgb, var(--color-surface-strong) 95%, transparent),
@@ -1006,6 +1008,7 @@ body::before {
 }
 
 .about-sticky__timeline {
+  grid-area: timeline;
   position: relative;
   display: flex;
   flex-direction: column;
@@ -1084,6 +1087,9 @@ body::before {
 @media (max-width: 1024px) {
   .about-sticky__body {
     grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "pin"
+      "timeline";
   }
 
   .about-sticky__pin {


### PR DESCRIPTION
## Summary
- reposition the about section timeline to the left by updating the grid layout
- trim the sticky panel and media card heights to add breathing room around the cards
- update the responsive grid template so the layout stacks cleanly on narrow screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1f795139483279d972d2cdae969a8