### PR TITLE
Adjust mobile timeline padding to match sticky offset

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1124,7 +1124,7 @@ body::before {
   }
 
   .about-sticky__timeline {
-    padding-block: 1rem 6rem;
+    padding-block: clamp(5rem, 7vw, 7rem) 6rem;
   }
 
   .about-stage {


### PR DESCRIPTION
## Summary
- align the mobile timeline padding with the sticky pin offset to maintain proper spacing

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e21f1fa184832798bd1de87cdb435f