### PR TITLE
Fix sticky pin layout on narrow screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -814,6 +814,7 @@ body::before {
   position: relative;
   display: grid;
   gap: clamp(3rem, 5vw, 4.8rem);
+  --about-sticky-offset: clamp(5.6rem, 6vw, 8rem);
 }
 
 .about-sticky::before {
@@ -902,7 +903,7 @@ body::before {
 .about-sticky__pin {
   grid-area: pin;
   position: sticky;
-  top: clamp(5.6rem, 6vw, 8rem);
+  top: var(--about-sticky-offset);
   display: grid;
   gap: clamp(1.1rem, 1.6vw, 1.8rem);
   align-self: start;
@@ -1013,7 +1014,8 @@ body::before {
   display: flex;
   flex-direction: column;
   gap: clamp(2rem, 4vw, 3rem);
-  padding-block: 1rem clamp(5rem, 8vw, 6rem);
+  padding-top: var(--about-sticky-offset);
+  padding-bottom: clamp(5rem, 8vw, 6rem);
   overflow: clip;
 }
 
@@ -1085,16 +1087,15 @@ body::before {
 }
 
 @media (max-width: 1024px) {
+  .about-sticky {
+    --about-sticky-offset: clamp(6.5rem, 10vw, 8.5rem);
+  }
+
   .about-sticky__body {
     grid-template-columns: minmax(0, 1fr);
     grid-template-areas:
-      "timeline"
-      "pin";
-  }
-
-  .about-sticky__pin {
-    position: static;
-    margin-top: clamp(1.6rem, 4vw, 2.2rem);
+      "pin"
+      "timeline";
   }
 
   .about-sticky__timeline::before {
@@ -1112,6 +1113,10 @@ body::before {
   }
 
   .about-sticky {
+    --about-sticky-offset: clamp(6.5rem, 14vw, 9rem);
+  }
+
+  .about-sticky {
     gap: 2.4rem;
   }
 
@@ -1120,7 +1125,7 @@ body::before {
   }
 
   .about-sticky__timeline {
-    padding-block: 1rem 6rem;
+    padding-bottom: 6rem;
   }
 
   .about-stage {


### PR DESCRIPTION
## Summary
- reorder the narrow layout so the pin area precedes the timeline
- restore sticky positioning for the pin and add timeline spacing to avoid overlap
- tie the sticky offset and timeline padding together with responsive CSS variables so the card never covers the timeline text

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e21c510d5c83278ba4fbd4f8c596ac