### PR TITLE
Fix DOM nesting in about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,6 +303,8 @@
               </div>
             </section>
           </div>
+        </div>
+      </section>
       <section
         class="section section--layered"
         id="projects"


### PR DESCRIPTION
## Summary
- close the about section container and section before the projects section to restore proper DOM nesting

## Testing
- python - <<'PY'
from html.parser import HTMLParser
class MyParser(HTMLParser):
    def error(self, message):
        raise RuntimeError(message)

with open('index.html', encoding='utf-8') as f:
    parser = MyParser()
    parser.feed(f.read())
print('Parsed without errors')
PY


------
https://chatgpt.com/codex/tasks/task_e_68e241cf1e508327a06d27aa7e823bc0