### PR TITLE
Rebuild about section parallax narrative

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,169 +144,174 @@
               以下以黏著式敘事整理我的背景、研究、獲獎與帶隊經驗。
             </p>
           </div>
-          <div class="about-sticky" data-about-sticky>
-            <div class="about-sticky__intro" data-animate="fade-up">
-              <span class="about-sticky__label">Profile</span>
-              <h3 class="about-sticky__title">跨越地球科學與資訊工程的產品創造者</h3>
-              <p class="about-sticky__description">
-                我在國立臺灣師範大學主修地球科學並雙主修資訊工程，
-                從專題研究、資料分析到互動產品開發一路親自實作。外向實事求是的個性讓我
-                擅長協調跨領域團隊，把複雜需求拆解成可以驗證的成果。
-              </p>
-              <dl class="about-sticky__facts">
-                <div>
-                  <dt>教育</dt>
-                  <dd>國立臺灣師範大學 地球科學系<br />雙主修資訊工程（2021.09 – 現在）</dd>
+          <div class="about-parallax">
+            <article class="about-scene about-scene--profile">
+              <section
+                class="about-parallax__hero about-parallax__hero--profile"
+                aria-labelledby="about-hero-profile"
+              >
+                <div class="container about-parallax__inner" data-animate="fade-up">
+                  <p class="about-parallax__eyebrow">Profile</p>
+                  <h3 class="about-parallax__title" id="about-hero-profile">
+                    跨越地球科學與資訊工程的產品創造者
+                  </h3>
+                  <p class="about-parallax__summary">
+                    我在國立臺灣師範大學主修地球科學並雙主修資訊工程，從專題研究、資料分析到互動產品開發一路親自實作，
+                    外向實事求是的個性讓我擅長協調跨領域團隊，把複雜需求拆解成可以驗證的成果。
+                  </p>
                 </div>
-                <div>
-                  <dt>研究領域</dt>
-                  <dd>資料分析、ML 模型壓縮、沉浸式互動系統、跨裝置體驗設計</dd>
-                </div>
-                <div>
-                  <dt>外語能力</dt>
-                  <dd>英文 TOEIC 765 分</dd>
-                </div>
-              </dl>
-            </div>
-            <div class="about-sticky__body">
-              <div class="about-sticky__pin" aria-live="polite">
-                <div class="about-sticky__panels">
-                  <article class="about-panel is-active" data-about-panel="profile" aria-hidden="false">
-                    <header>
-                      <h3>個人簡介</h3>
+              </section>
+              <section class="about-parallax__content about-parallax__content--profile">
+                <div class="container">
+                  <div class="about-parallax__grid" data-animate-group data-animate-interval="160">
+                    <article class="about-parallax__card" data-animate="fade-up">
+                      <h4 class="about-parallax__heading">個人簡介</h4>
                       <p>
-                        我熱愛把研究成果轉化為實際應用，自大二起持續投入跨領域專題。開朗外向且善於表達，
-                        喜歡帶著團隊一起把想法落實，確保每一步都有數據與故事支撐。
+                        我熱愛把研究成果轉化為實際應用，自大二起持續投入跨領域專題。開朗外向且善於表達，喜歡帶著團隊一起把想法落實，
+                        確保每一步都有數據與故事支撐。
                       </p>
-                    </header>
-                  </article>
-                  <article class="about-panel" data-about-panel="research" aria-hidden="true">
-                    <header>
-                      <h3>專題研究</h3>
-                    </header>
-                    <ul class="about-panel__list">
-                      <li>
-                        <strong>颱風對海洋表層葉綠素 a 影響之研究｜2018.09 – 2021.10</strong><br />
-                        以 MATLAB 分析西北太平洋颱風對藻類數量的影響，獲「美國氣象學會獎」。
-                      </li>
-                      <li>
-                        <strong>Model Selection: Trade-Offs Between Model Size and Predictive Accuracy｜2023.10 – 2024.01</strong><br />
-                        探討模型大小與準確率的平衡，透過超參數調整提升小型模型表現。
-                      </li>
-                    </ul>
-                  </article>
-                  <article class="about-panel" data-about-panel="awards" aria-hidden="true">
-                    <header>
-                      <h3>競賽與獲獎</h3>
-                    </header>
-                    <ul class="about-panel__list">
-                      <li>OpenHCI 2024 人機互動工作坊 <strong>最佳 Demo 獎</strong>（ME_NU 菜單推薦系統）。</li>
-                      <li>Normal Game Jam 2024 <strong>Gameplay 第一名、Overall 第三名</strong>（Show the Sheep）。</li>
-                      <li>師大地科五育獎學金連續 <strong>5</strong> 次獲獎（2022.01 – 2023.09）。</li>
-                    </ul>
-                  </article>
-                  <article class="about-panel" data-about-panel="experience" aria-hidden="true">
-                    <header>
-                      <h3>工作經驗</h3>
-                    </header>
-                    <ul class="about-panel__list">
-                      <li>國立臺灣師範大學智慧運算導向永續發展研究中心 網頁維護總負責人（2023.09 – 現在）。</li>
-                      <li>國立臺灣師範大學地球科學系 網頁維護總負責人（2023.02 – 現在）。</li>
-                      <li>攜曦程式推廣學會 Python 課程助教（2021.09 – 2021.12）。</li>
-                    </ul>
-                  </article>
-                  <article class="about-panel" data-about-panel="projects" aria-hidden="true">
-                    <header>
-                      <h3>專案亮點</h3>
-                    </header>
-                    <ul class="about-panel__list">
-                      <li>動態背光調光系統自行設計硬體與韌體，將成本降至市售方案的 10%。</li>
-                      <li>Your Sky Pylot 平台整合多來源資料並提供互動儀表，讓使用者快速掌握觀星條件。</li>
-                    </ul>
-                  </article>
-                  <article class="about-panel" data-about-panel="leadership" aria-hidden="true">
-                    <header>
-                      <h3>社團與領導</h3>
-                    </header>
-                    <ul class="about-panel__list">
-                      <li>國立臺灣大學慈幼山地服務團利稻家 帶隊總召（2021.09 – 2021.12），領導 30 人籌辦 9 天營隊。</li>
-                      <li>師大地科展 2023 總召（2021.09 – 2021.12），與 Open House 合作規劃科普活動。</li>
-                    </ul>
-                  </article>
-                </div>
-                <div class="about-sticky__media">
-                  <div class="about-media__item is-active" data-about-media="profile" aria-hidden="false">
-                    <span class="about-media__icon" aria-hidden="true">🌱</span>
-                    <p class="about-media__caption">跨領域養成，轉化研究成產品故事</p>
-                  </div>
-                  <div class="about-media__item" data-about-media="research" aria-hidden="true">
-                    <span class="about-media__icon" aria-hidden="true">🔬</span>
-                    <p class="about-media__caption">以資料分析與模型調校累積研究底蘊</p>
-                  </div>
-                  <div class="about-media__item" data-about-media="awards" aria-hidden="true">
-                    <span class="about-media__icon" aria-hidden="true">🏅</span>
-                    <p class="about-media__caption">競賽肯定帶來快速驗證與迭代能力</p>
-                  </div>
-                  <div class="about-media__item" data-about-media="experience" aria-hidden="true">
-                    <span class="about-media__icon" aria-hidden="true">💼</span>
-                    <p class="about-media__caption">維運組織網站與跨部門協作的實戰經驗</p>
-                  </div>
-                  <div class="about-media__item" data-about-media="projects" aria-hidden="true">
-                    <span class="about-media__icon" aria-hidden="true">🛠️</span>
-                    <p class="about-media__caption">從硬體到平台的 MVP 交付與迭代</p>
-                  </div>
-                  <div class="about-media__item" data-about-media="leadership" aria-hidden="true">
-                    <span class="about-media__icon" aria-hidden="true">🤝</span>
-                    <p class="about-media__caption">領導大型活動，培養共創與溝通能力</p>
+                    </article>
+                    <article class="about-parallax__card about-parallax__card--facts" data-animate="fade-up">
+                      <h4 class="about-parallax__heading">背景速記</h4>
+                      <dl class="about-parallax__facts">
+                        <div>
+                          <dt>教育</dt>
+                          <dd>國立臺灣師範大學 地球科學系<br />雙主修資訊工程（2021.09 – 現在）</dd>
+                        </div>
+                        <div>
+                          <dt>研究領域</dt>
+                          <dd>資料分析、ML 模型壓縮、沉浸式互動系統、跨裝置體驗設計</dd>
+                        </div>
+                        <div>
+                          <dt>外語能力</dt>
+                          <dd>英文 TOEIC 765 分</dd>
+                        </div>
+                      </dl>
+                    </article>
+                    <article class="about-parallax__card about-parallax__card--highlight" data-animate="fade-up">
+                      <span class="about-parallax__step">01</span>
+                      <h5>跨域養成</h5>
+                      <p>地科與資工並進，擅長用故事與數據連結跨領域團隊。</p>
+                    </article>
                   </div>
                 </div>
-              </div>
-              <div class="about-sticky__timeline" data-animate-group data-animate-interval="160">
-                <article class="about-stage is-active" data-about-stage="profile" data-animate="fade-up">
-                  <span class="about-stage__number">01</span>
-                  <div class="about-stage__content">
-                    <h3>跨域養成</h3>
-                    <p>地科與資工並進，擅長用故事與數據連結跨領域團隊。</p>
+              </section>
+            </article>
+            <article class="about-scene about-scene--research">
+              <section
+                class="about-parallax__hero about-parallax__hero--research"
+                aria-labelledby="about-hero-research"
+              >
+                <div class="container about-parallax__inner" data-animate="fade-up">
+                  <p class="about-parallax__eyebrow">Research &amp; Awards</p>
+                  <h3 class="about-parallax__title" id="about-hero-research">
+                    以研究與競賽磨練資料與 AI 實力
+                  </h3>
+                  <p class="about-parallax__summary">
+                    從衛星資料分析到模型調校，持續打磨資料科學與 AI 能力；也透過多次競賽獲獎，快速迭代產品並驗證創意。
+                  </p>
+                </div>
+              </section>
+              <section class="about-parallax__content about-parallax__content--research">
+                <div class="container">
+                  <div class="about-parallax__grid" data-animate-group data-animate-interval="150">
+                    <article class="about-parallax__card" data-animate="fade-up">
+                      <h4 class="about-parallax__heading">專題研究</h4>
+                      <ul class="about-parallax__list">
+                        <li>
+                          <strong>颱風對海洋表層葉綠素 a 影響之研究｜2018.09 – 2021.10</strong><br />
+                          以 MATLAB 分析西北太平洋颱風對藻類數量的影響，獲「美國氣象學會獎」。
+                        </li>
+                        <li>
+                          <strong>Model Selection: Trade-Offs Between Model Size and Predictive Accuracy｜2023.10 – 2024.01</strong><br />
+                          探討模型大小與準確率的平衡，透過超參數調整提升小型模型表現。
+                        </li>
+                      </ul>
+                    </article>
+                    <article class="about-parallax__card" data-animate="fade-up">
+                      <h4 class="about-parallax__heading">競賽與獲獎</h4>
+                      <ul class="about-parallax__list">
+                        <li>OpenHCI 2024 人機互動工作坊 <strong>最佳 Demo 獎</strong>（ME_NU 菜單推薦系統）。</li>
+                        <li>Normal Game Jam 2024 <strong>Gameplay 第一名、Overall 第三名</strong>（Show the Sheep）。</li>
+                        <li>師大地科五育獎學金連續 <strong>5</strong> 次獲獎（2022.01 – 2023.09）。</li>
+                      </ul>
+                    </article>
+                    <article class="about-parallax__card about-parallax__card--highlight" data-animate="fade-up">
+                      <span class="about-parallax__step">02</span>
+                      <h5>研究實力</h5>
+                      <p>從衛星資料分析到模型調校，持續打磨資料與 AI 能力。</p>
+                    </article>
+                    <article class="about-parallax__card about-parallax__card--highlight" data-animate="fade-up">
+                      <span class="about-parallax__step">03</span>
+                      <h5>競賽成果</h5>
+                      <p>多次獲獎驗證創新實力，也把使用者回饋導入下一版。</p>
+                    </article>
                   </div>
-                </article>
-                <article class="about-stage" data-about-stage="research" data-animate="fade-up">
-                  <span class="about-stage__number">02</span>
-                  <div class="about-stage__content">
-                    <h3>研究實力</h3>
-                    <p>從衛星資料分析到模型調校，持續打磨資料與 AI 能力。</p>
+                </div>
+              </section>
+            </article>
+            <article class="about-scene about-scene--experience">
+              <section
+                class="about-parallax__hero about-parallax__hero--experience"
+                aria-labelledby="about-hero-experience"
+              >
+                <div class="container about-parallax__inner" data-animate="fade-up">
+                  <p class="about-parallax__eyebrow">Experience &amp; Leadership</p>
+                  <h3 class="about-parallax__title" id="about-hero-experience">
+                    從實務維運到領導協作的全方位歷練
+                  </h3>
+                  <p class="about-parallax__summary">
+                    長期維運大型網站、打造硬軟整合專案，並策畫營隊與科普活動，培養快速協作與臨場應變能力。
+                  </p>
+                </div>
+              </section>
+              <section class="about-parallax__content about-parallax__content--experience">
+                <div class="container">
+                  <div class="about-parallax__grid" data-animate-group data-animate-interval="150">
+                    <article class="about-parallax__card" data-animate="fade-up">
+                      <h4 class="about-parallax__heading">工作經驗</h4>
+                      <ul class="about-parallax__list">
+                        <li>國立臺灣師範大學智慧運算導向永續發展研究中心 網頁維護總負責人（2023.09 – 現在）。</li>
+                        <li>國立臺灣師範大學地球科學系 網頁維護總負責人（2023.02 – 現在）。</li>
+                        <li>攜曦程式推廣學會 Python 課程助教（2021.09 – 2021.12）。</li>
+                      </ul>
+                    </article>
+                    <article class="about-parallax__card" data-animate="fade-up">
+                      <h4 class="about-parallax__heading">專案亮點</h4>
+                      <ul class="about-parallax__list">
+                        <li>動態背光調光系統自行設計硬體與韌體，將成本降至市售方案的 10%。</li>
+                        <li>Your Sky Pylot 平台整合多來源資料並提供互動儀表，讓使用者快速掌握觀星條件。</li>
+                      </ul>
+                    </article>
+                    <article class="about-parallax__card" data-animate="fade-up">
+                      <h4 class="about-parallax__heading">社團與領導</h4>
+                      <ul class="about-parallax__list">
+                        <li>國立臺灣大學慈幼山地服務團利稻家 帶隊總召（2021.09 – 2021.12），領導 30 人籌辦 9 天營隊。</li>
+                        <li>師大地科展 2023 總召（2021.09 – 2021.12），與 Open House 合作規劃科普活動。</li>
+                      </ul>
+                    </article>
+                    <article class="about-parallax__card about-parallax__card--highlight" data-animate="fade-up">
+                      <span class="about-parallax__step">04</span>
+                      <h5>實務經驗</h5>
+                      <p>長期維運校內大型網站，與跨單位協作完成上線。</p>
+                    </article>
+                    <article class="about-parallax__card about-parallax__card--highlight" data-animate="fade-up">
+                      <span class="about-parallax__step">05</span>
+                      <h5>專案亮點</h5>
+                      <p>打造硬軟整合產品與資料平台，著重體驗與可行性。</p>
+                    </article>
+                    <article class="about-parallax__card about-parallax__card--highlight" data-animate="fade-up">
+                      <span class="about-parallax__step">06</span>
+                      <h5>領導協作</h5>
+                      <p>策畫營隊與科普活動，訓練決策、溝通與臨場應變。</p>
+                    </article>
                   </div>
-                </article>
-                <article class="about-stage" data-about-stage="awards" data-animate="fade-up">
-                  <span class="about-stage__number">03</span>
-                  <div class="about-stage__content">
-                    <h3>競賽成果</h3>
-                    <p>多次獲獎驗證創新實力，也把使用者回饋導入下一版。</p>
-                  </div>
-                </article>
-                <article class="about-stage" data-about-stage="experience" data-animate="fade-up">
-                  <span class="about-stage__number">04</span>
-                  <div class="about-stage__content">
-                    <h3>實務經驗</h3>
-                    <p>長期維運校內大型網站，與跨單位協作完成上線。</p>
-                  </div>
-                </article>
-                <article class="about-stage" data-about-stage="projects" data-animate="fade-up">
-                  <span class="about-stage__number">05</span>
-                  <div class="about-stage__content">
-                    <h3>專案亮點</h3>
-                    <p>打造硬軟整合產品與資料平台，著重體驗與可行性。</p>
-                  </div>
-                </article>
-                <article class="about-stage" data-about-stage="leadership" data-animate="fade-up">
-                  <span class="about-stage__number">06</span>
-                  <div class="about-stage__content">
-                    <h3>領導協作</h3>
-                    <p>策畫營隊與科普活動，訓練決策、溝通與臨場應變。</p>
-                  </div>
-                </article>
-              </div>
-            </div>
+                </div>
+              </section>
+            </article>
           </div>
+        </div>
+      </section>
       <section
         class="section section--layered"
         id="projects"

--- a/script.js
+++ b/script.js
@@ -35,7 +35,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const autoAnimateGroups = [
     [".hero__stats", 120],
-    [".about-sticky__timeline", 160],
+    [".about-parallax__grid", 150],
     [".project-timeline", 140],
     [".project-detail__main", 140],
     [".project-sidebar", 160],
@@ -221,81 +221,6 @@ document.addEventListener("DOMContentLoaded", () => {
       prefersReducedMotion.addListener(handleParallaxPreference);
     }
   }
-
-  const aboutStickyLayouts = document.querySelectorAll("[data-about-sticky]");
-
-  aboutStickyLayouts.forEach((layout) => {
-    const stages = Array.from(layout.querySelectorAll("[data-about-stage]"));
-    const panels = Array.from(layout.querySelectorAll("[data-about-panel]"));
-    const mediaItems = Array.from(layout.querySelectorAll("[data-about-media]"));
-
-    if (!stages.length || !panels.length) {
-      return;
-    }
-
-    let activeId = "";
-
-    const setActiveStage = (id) => {
-      panels.forEach((panel) => {
-        const isMatch = panel.dataset.aboutPanel === id;
-        panel.classList.toggle("is-active", isMatch);
-        panel.setAttribute("aria-hidden", (!isMatch).toString());
-      });
-
-      mediaItems.forEach((item) => {
-        const isMatch = item.dataset.aboutMedia === id;
-        item.classList.toggle("is-active", isMatch);
-        item.setAttribute("aria-hidden", (!isMatch).toString());
-      });
-
-      stages.forEach((stage) => {
-        stage.classList.toggle("is-active", stage.dataset.aboutStage === id);
-      });
-    };
-
-    const updateActiveStage = () => {
-      const viewportHeight = window.innerHeight || 1;
-      const focusLine = viewportHeight * 0.45;
-      let closestStage = stages[0];
-      let smallestDistance = Number.POSITIVE_INFINITY;
-
-      stages.forEach((stage) => {
-        const rect = stage.getBoundingClientRect();
-        const midpoint = rect.top + rect.height / 2;
-        const distance = Math.abs(midpoint - focusLine);
-        if (distance < smallestDistance) {
-          smallestDistance = distance;
-          closestStage = stage;
-        }
-      });
-
-      if (!closestStage) {
-        return;
-      }
-
-      const nextId = closestStage.dataset.aboutStage || "";
-      if (nextId && nextId !== activeId) {
-        activeId = nextId;
-        setActiveStage(activeId);
-      }
-    };
-
-    let ticking = false;
-    const requestUpdate = () => {
-      if (ticking) {
-        return;
-      }
-      ticking = true;
-      requestAnimationFrame(() => {
-        ticking = false;
-        updateActiveStage();
-      });
-    };
-
-    updateActiveStage();
-    window.addEventListener("scroll", requestUpdate, { passive: true });
-    window.addEventListener("resize", requestUpdate);
-  });
 
   const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
   const storedTheme = localStorage.getItem("patrick-theme");

--- a/styles.css
+++ b/styles.css
@@ -810,348 +810,412 @@ body::before {
   overflow: clip;
 }
 
-.about-sticky {
+.about-parallax {
   position: relative;
+  margin-top: clamp(3rem, 4vw, 4.8rem);
+  perspective: 1px;
+  transform-style: preserve-3d;
+  overflow-x: clip;
   display: grid;
-  gap: clamp(3rem, 5vw, 4.8rem);
+  gap: clamp(6rem, 9vh, 9rem);
 }
 
-.about-sticky::before {
+.about-scene {
+  position: relative;
+  transform-style: preserve-3d;
+}
+
+.about-parallax__hero,
+.about-parallax__content {
+  position: relative;
+  transform-style: inherit;
+}
+
+.about-parallax__hero {
+  min-height: clamp(82vh, 92vh, 104vh);
+  display: grid;
+  place-items: center;
+  padding: clamp(5.5rem, 14vh, 9rem) clamp(1.8rem, 6vw, 4.5rem);
+  text-align: center;
+  color: #f5f8ff;
+  overflow: hidden;
+  isolation: isolate;
+  border-radius: clamp(1.6rem, 2.4vw, 3rem);
+  box-shadow: 0 24px 72px rgba(15, 23, 42, 0.26);
+}
+
+.about-parallax__hero::before,
+.about-parallax__hero::after {
   content: "";
   position: absolute;
-  inset: -8%;
-  background: radial-gradient(circle at 20% 0%, rgba(79, 70, 229, 0.18), transparent 55%),
-    radial-gradient(circle at 80% 100%, rgba(56, 189, 248, 0.14), transparent 60%);
-  filter: blur(40px);
-  opacity: 0.6;
+  inset: -22% -14%;
   pointer-events: none;
+  will-change: transform;
+}
+
+.about-parallax__hero::before {
+  background: var(--hero-image);
+  transform: translateZ(-0.75px) scale(2.3);
+  filter: blur(2px);
+  opacity: 0.96;
+  z-index: -2;
+}
+
+.about-parallax__hero::after {
+  inset: -10% -8%;
+  background: linear-gradient(
+    165deg,
+    color-mix(in srgb, var(--hero-overlay) 96%, transparent) 0%,
+    rgba(15, 23, 42, 0.55) 100%
+  );
+  transform: translateZ(-0.4px) scale(1.7);
+  opacity: 0.88;
   z-index: -1;
 }
 
-.about-sticky__intro {
-  position: relative;
-  padding: clamp(2rem, 2vw + 1.6rem, 2.75rem) clamp(2.2rem, 3vw, 3rem);
-  border-radius: 1.9rem;
-  background: color-mix(in srgb, var(--color-surface-strong) 88%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
-  box-shadow: 0 32px 70px rgba(15, 23, 42, 0.18);
-  backdrop-filter: blur(28px);
+.about-parallax__hero--profile {
+  --hero-image: radial-gradient(circle at 16% 28%, rgba(79, 70, 229, 0.82), transparent 62%),
+    radial-gradient(circle at 78% 64%, rgba(56, 189, 248, 0.65), transparent 66%),
+    radial-gradient(circle at 50% 110%, rgba(236, 72, 153, 0.5), transparent 74%);
+  --hero-overlay: rgba(25, 33, 56, 0.88);
+}
+
+.about-parallax__hero--research {
+  --hero-image: radial-gradient(circle at 20% 30%, rgba(236, 72, 153, 0.82), transparent 60%),
+    radial-gradient(circle at 80% 66%, rgba(192, 132, 252, 0.74), transparent 68%),
+    radial-gradient(circle at 56% 108%, rgba(14, 165, 233, 0.54), transparent 76%);
+  --hero-overlay: rgba(26, 18, 48, 0.88);
+}
+
+.about-parallax__hero--experience {
+  --hero-image: radial-gradient(circle at 18% 30%, rgba(16, 185, 129, 0.76), transparent 62%),
+    radial-gradient(circle at 78% 66%, rgba(14, 165, 233, 0.64), transparent 68%),
+    radial-gradient(circle at 56% 110%, rgba(250, 204, 21, 0.5), transparent 78%);
+  --hero-overlay: rgba(17, 35, 39, 0.88);
+}
+
+body.theme-dark .about-parallax__hero::after {
+  background: linear-gradient(
+    165deg,
+    color-mix(in srgb, var(--hero-overlay) 92%, transparent) 0%,
+    rgba(2, 6, 23, 0.55) 100%
+  );
+  opacity: 0.82;
+}
+
+.about-parallax__inner {
+  width: min(720px, 92vw);
   display: grid;
-  gap: 1.3rem;
-  overflow: clip;
+  gap: 1.2rem;
+  justify-items: center;
 }
 
-.about-sticky__label {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  padding: 0.35rem 0.8rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--color-primary) 26%, transparent);
-  color: #fff;
-  font-size: 0.8rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.about-sticky__title {
+.about-parallax__inner > * {
   margin: 0;
-  font-size: clamp(2.1rem, 1.4rem + 1.8vw, 2.8rem);
 }
 
-.about-sticky__description {
-  margin: 0;
-  color: var(--color-muted);
+.about-parallax__inner p {
   line-height: 1.8;
-  font-size: clamp(1rem, 0.92rem + 0.28vw, 1.12rem);
 }
 
-.about-sticky__facts {
+.about-parallax__eyebrow {
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.about-parallax__title {
   margin: 0;
+  font-size: clamp(2rem, 2.2vw + 1.1rem, 2.9rem);
+  letter-spacing: 0.02em;
+}
+
+.about-parallax__summary {
+  max-width: 50ch;
+  font-size: clamp(1.05rem, 1vw + 0.9rem, 1.2rem);
+  opacity: 0.92;
+}
+
+.about-parallax__content {
+  display: flex;
+  justify-content: center;
+  margin: 0;
+  padding: clamp(0rem, 1vh, 1rem) 0 clamp(6rem, 9vh, 8rem);
+}
+
+.about-parallax__content::before {
+  content: "";
+  position: absolute;
+  inset: -16% -10%;
+  border-radius: clamp(2rem, 3vw, 3.4rem);
+  background: radial-gradient(circle at 22% 20%, var(--panel-glow, rgba(79, 70, 229, 0.26)), transparent 58%),
+    radial-gradient(circle at 78% 70%, color-mix(in srgb, var(--panel-secondary) 55%, transparent), transparent 60%),
+    linear-gradient(
+      140deg,
+      color-mix(in srgb, var(--panel-primary) 62%, transparent) 0%,
+      color-mix(in srgb, var(--panel-secondary) 60%, transparent) 100%
+    );
+  transform: translateZ(-0.45px) scale(1.45);
+  opacity: 0.72;
+  filter: blur(0.5px);
+  z-index: -2;
+}
+
+.about-parallax__content > .container {
+  position: relative;
+  width: min(1000px, 92vw);
+  background: color-mix(in srgb, var(--color-surface) 94%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 68%, transparent);
+  border-radius: clamp(1.8rem, 2.4vw, 2.8rem);
+  padding: clamp(3.4rem, 5vw, 4.6rem) clamp(2.2rem, 6vw, 3.6rem);
+  box-shadow: 0 24px 72px rgba(15, 23, 42, 0.16);
+  backdrop-filter: blur(20px);
+}
+
+body.theme-dark .about-parallax__content > .container {
+  background: color-mix(in srgb, var(--color-surface-strong) 88%, transparent);
+  border-color: color-mix(in srgb, var(--color-border) 60%, transparent);
+  box-shadow: 0 26px 74px rgba(6, 11, 30, 0.45);
+}
+
+.about-parallax__content--profile {
+  --panel-primary: rgba(99, 102, 241, 0.5);
+  --panel-secondary: rgba(56, 189, 248, 0.46);
+  --panel-glow: rgba(236, 72, 153, 0.34);
+  --highlight-primary: rgba(99, 102, 241, 0.9);
+  --highlight-secondary: rgba(56, 189, 248, 0.82);
+}
+
+.about-parallax__content--research {
+  --panel-primary: rgba(236, 72, 153, 0.52);
+  --panel-secondary: rgba(192, 132, 252, 0.52);
+  --panel-glow: rgba(14, 165, 233, 0.34);
+  --highlight-primary: rgba(236, 72, 153, 0.92);
+  --highlight-secondary: rgba(192, 132, 252, 0.78);
+}
+
+.about-parallax__content--experience {
+  --panel-primary: rgba(16, 185, 129, 0.5);
+  --panel-secondary: rgba(14, 165, 233, 0.46);
+  --panel-glow: rgba(250, 204, 21, 0.32);
+  --highlight-primary: rgba(16, 185, 129, 0.9);
+  --highlight-secondary: rgba(14, 165, 233, 0.76);
+}
+
+.about-parallax__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(1.8rem, 3vw, 2.8rem);
+}
+
+.about-parallax__card {
+  background: color-mix(in srgb, var(--color-surface-strong) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 75%, transparent);
+  border-radius: 1.4rem;
+  padding: clamp(1.8rem, 3vw, 2.2rem);
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(14px);
+  display: grid;
+  gap: 0.85rem;
+  line-height: 1.7;
+  transition: transform 0.3s var(--transition), box-shadow 0.3s var(--transition);
+}
+
+body.theme-dark .about-parallax__card {
+  background: color-mix(in srgb, var(--color-surface) 84%, transparent);
+  border-color: color-mix(in srgb, var(--color-border) 58%, transparent);
+  box-shadow: 0 20px 54px rgba(6, 11, 30, 0.38);
+}
+
+.about-parallax__card p {
+  margin: 0;
+}
+
+.about-parallax__heading {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.about-parallax__facts {
   display: grid;
   gap: 1.2rem;
 }
 
-.about-sticky__facts div {
+.about-parallax__facts div {
   display: grid;
-  gap: 0.4rem;
+  gap: 0.45rem;
 }
 
-.about-sticky__facts dt {
-  font-size: 0.82rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--color-muted) 65%, transparent);
-}
-
-.about-sticky__facts dd {
-  margin: 0;
-  color: color-mix(in srgb, var(--color-text) 92%, transparent);
-  line-height: 1.65;
-  font-size: 0.98rem;
-}
-
-.about-sticky__body {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 420px);
-  grid-template-areas: "timeline pin";
-  gap: clamp(2.8rem, 6vw, 5.4rem);
-  align-items: start;
-}
-
-.about-sticky__pin {
-  grid-area: pin;
-  position: sticky;
-  top: clamp(5.6rem, 6vw, 8rem);
-  display: grid;
-  gap: clamp(1.1rem, 1.6vw, 1.8rem);
-  align-self: start;
-}
-
-.about-sticky__panels {
-  position: relative;
-  min-height: clamp(200px, 24vw, 300px);
-}
-
-.about-panel {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  gap: 1.1rem;
-  padding: 0 0.3rem;
-  opacity: 0;
-  transform: translateY(30px);
-  transition: opacity var(--transition), transform var(--transition);
-  pointer-events: none;
-}
-
-.about-panel.is-active {
-  opacity: 1;
-  transform: translateY(0);
-  pointer-events: auto;
-}
-
-.about-panel header h3 {
-  margin: 0 0 0.2rem;
-  font-size: clamp(1.35rem, 1rem + 1vw, 1.9rem);
-  line-height: 1.25;
-}
-.about-panel header p {
-  margin: 0;
-  font-size: clamp(1.02rem, 0.95rem + 0.35vw, 1.15rem);
-  line-height: 1.8;
-  color: color-mix(in srgb, var(--color-text) 94%, transparent);
-}
-
-.about-panel__list {
-  margin: 0;
-  padding-left: 1.2rem;
-  display: grid;
-  gap: 0.65rem;
-  color: color-mix(in srgb, var(--color-text) 94%, transparent);
-  line-height: 1.75;
-}
-
-.about-panel__list strong {
-  color: var(--color-primary);
-  font-weight: 700;
-}
-
-.about-sticky__media {
-  position: relative;
-  min-height: clamp(200px, 24vw, 300px);
-  margin-bottom: 0.5rem;
-  border-radius: 1.9rem;
-  background: linear-gradient(160deg, color-mix(in srgb, var(--color-surface-strong) 95%, transparent),
-      color-mix(in srgb, var(--color-primary) 18%, transparent));
-  border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
-  overflow: hidden;
-  box-shadow: 0 26px 60px rgba(15, 23, 42, 0.2);
-}
-
-.about-media__item {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  align-content: center;
-  justify-items: center;
-  gap: 1.1rem;
-  padding: clamp(2rem, 3vw, 2.8rem);
-  opacity: 0;
-  transform: translateY(40px) scale(0.96);
-  transition: opacity var(--transition), transform var(--transition);
-  color: color-mix(in srgb, var(--color-text) 96%, transparent);
-}
-
-.about-media__item.is-active {
-  opacity: 1;
-  transform: translateY(0) scale(1);
-}
-
-.about-media__icon {
-  display: grid;
-  place-items: center;
-  width: clamp(3.8rem, 3.2rem + 1.8vw, 4.4rem);
-  height: clamp(3.8rem, 3.2rem + 1.8vw, 4.4rem);
-  border-radius: 1.3rem;
-  background: linear-gradient(145deg, rgba(79, 70, 229, 0.9), rgba(236, 72, 153, 0.78));
-  font-size: clamp(1.8rem, 1.5rem + 0.8vw, 2.2rem);
-  color: #fff;
-  box-shadow: 0 18px 38px rgba(79, 70, 229, 0.32);
-}
-
-.about-media__caption {
-  margin: 0;
-  max-width: 18ch;
-  text-align: center;
-  line-height: 1.6;
-}
-
-.about-sticky__timeline {
-  grid-area: timeline;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: clamp(2rem, 4vw, 3rem);
-  padding-block: 1rem clamp(5rem, 8vw, 6rem);
-  overflow: clip;
-}
-
-.about-sticky__timeline::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: clamp(1.4rem, 2vw, 2.1rem);
-  width: 2px;
-  background: color-mix(in srgb, var(--color-border) 70%, transparent);
-}
-
-.about-stage {
-  position: relative;
-  min-height: clamp(280px, 34vh, 520px);
-  padding-left: clamp(3.5rem, 3vw + 2.6rem, 4.6rem);
-  display: grid;
-  align-content: center;
-  gap: 0.9rem;
-  color: color-mix(in srgb, var(--color-muted) 80%, transparent);
-}
-
-.about-stage::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: clamp(1.2rem, 2vw, 1.9rem);
-  width: 2px;
-  height: 100%;
-  background: linear-gradient(180deg, color-mix(in srgb, var(--color-primary) 45%, transparent), transparent 82%);
-  opacity: 0;
-  transition: opacity var(--transition);
-}
-
-.about-stage.is-active::before {
-  opacity: 1;
-}
-
-.about-stage.is-active {
-  color: color-mix(in srgb, var(--color-text) 92%, transparent);
-}
-
-.about-stage__number {
-  position: absolute;
-  top: 1.1rem;
-  left: 0;
-  transform: none;
-  font-size: 1.2rem;
+.about-parallax__facts dt {
   font-weight: 600;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--color-muted) 60%, transparent);
+  color: var(--color-text);
 }
 
-.about-stage.is-active .about-stage__number {
-  color: var(--color-primary);
-}
-
-.about-stage__content h3 {
+.about-parallax__facts dd {
   margin: 0;
-  font-size: clamp(1.35rem, 1.15rem + 0.8vw, 1.8rem);
-}
-
-.about-stage__content p {
-  margin: 0;
-  max-width: 42ch;
+  color: var(--color-muted);
   line-height: 1.7;
 }
 
+.about-parallax__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1.1rem;
+}
+
+.about-parallax__list li {
+  position: relative;
+  padding-left: 1.35rem;
+}
+
+.about-parallax__list li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.55rem;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: var(--color-primary);
+  opacity: 0.55;
+}
+
+.about-parallax__card--highlight {
+  background: linear-gradient(
+      140deg,
+      color-mix(in srgb, var(--highlight-primary) 65%, transparent) 0%,
+      color-mix(in srgb, var(--highlight-secondary) 65%, transparent) 100%
+    ),
+    rgba(10, 12, 28, 0.25);
+  color: #fbfbff;
+  border-color: transparent;
+  box-shadow: 0 28px 56px color-mix(in srgb, var(--highlight-primary) 55%, transparent);
+  text-align: left;
+}
+
+.about-parallax__card--highlight p {
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.about-parallax__step {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.2rem;
+  height: 3.2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: rgba(255, 255, 255, 0.12);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  font-size: 1.1rem;
+}
+
+.about-parallax__card--highlight h5 {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+@media (hover: hover) {
+  .about-parallax__card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 24px 62px rgba(15, 23, 42, 0.2);
+  }
+
+  .about-parallax__card--highlight:hover {
+    box-shadow: 0 32px 70px color-mix(in srgb, var(--highlight-primary) 68%, transparent);
+  }
+}
+
 @media (max-width: 1024px) {
-  .about-sticky__body {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-areas:
-      "pin"
-      "timeline";
+  .about-parallax {
+    gap: clamp(5rem, 8vh, 7.5rem);
   }
 
-  .about-sticky__pin {
-    position: sticky;
-    top: clamp(5rem, 7vw, 7rem);
+  .about-parallax__hero {
+    min-height: clamp(76vh, 86vh, 98vh);
+    padding: clamp(5rem, 12vh, 8rem) clamp(1.5rem, 7vw, 3.5rem);
   }
 
-  .about-sticky__timeline {
-    padding-top: clamp(2rem, 6vw, 3rem);
-  }
-
-  .about-sticky__timeline::before {
-    left: 1rem;
-  }
-
-  .about-stage {
-    padding-left: 3.4rem;
+  .about-parallax__content > .container {
+    padding: clamp(3rem, 5vw, 4rem) clamp(2rem, 6vw, 3.2rem);
   }
 }
 
 @media (max-width: 720px) {
   .section--sticky {
-    padding-block: 4.8rem 7.2rem;
+    padding-block: 4.8rem 7rem;
   }
 
-  .about-sticky {
-    gap: 2.4rem;
+  .about-parallax {
+    gap: clamp(4rem, 8vh, 6rem);
+    perspective: 1200px;
   }
 
-  .about-sticky__intro {
-    padding: 1.6rem 1.9rem;
+  .about-parallax__hero {
+    min-height: clamp(68vh, 78vh, 88vh);
+    border-radius: 2rem;
+    padding: clamp(4.5rem, 18vh, 7rem) clamp(1.2rem, 8vw, 2.4rem);
   }
 
-  .about-sticky__timeline {
-    padding-block: 1rem 6rem;
+  .about-parallax__content {
+    padding-bottom: clamp(5rem, 9vh, 6.5rem);
   }
 
-  .about-stage {
-    min-height: clamp(220px, 42vh, 360px);
+  .about-parallax__content > .container {
+    width: min(94vw, 720px);
+    border-radius: 1.8rem;
   }
 
-  .about-sticky__media {
-    min-height: clamp(220px, 60vw, 320px);
+  .about-parallax__grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
 @media (max-width: 560px) {
-  .about-stage {
-    min-height: clamp(200px, 38vh, 320px);
-    padding-left: 2.6rem;
+  .about-parallax {
+    perspective: none;
   }
 
-  .about-stage__number {
-    font-size: 1rem;
+  .about-parallax__hero {
+    min-height: clamp(60vh, 70vh, 82vh);
+    padding: clamp(4rem, 20vh, 6.2rem) clamp(1rem, 8vw, 2rem);
   }
 
-  .about-sticky__timeline::before {
-    left: 0.85rem;
+  .about-parallax__hero::before,
+  .about-parallax__hero::after,
+  .about-parallax__content::before {
+    transform: none;
+  }
+
+  .about-parallax__content {
+    padding-bottom: 5rem;
+  }
+
+  .about-parallax__content > .container {
+    width: min(94vw, 640px);
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .about-parallax {
+    perspective: none;
+  }
 
+  .about-parallax__hero::before,
+  .about-parallax__hero::after,
+  .about-parallax__content::before {
+    transform: none;
+  }
+}
 .filter-controls {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- wrap each about theme in its own parallax scene so hero panels and content stacks scroll cleanly without overlapping
- rebuild the parallax styling with translateZ background layers and halo panels to deliver the intended CSS parallax motion
- refresh the content card styling and responsive breakpoints to keep timelines legible across screen sizes

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e21f1fa184832798bd1de87cdb435f