### PR TITLE
Restore scroll-to-top behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,32 +128,28 @@
         </div>
       </section>
 
-      <section
-        class="section section--soft section--sticky"
-        id="about"
-        aria-labelledby="about-heading"
-        data-snap-section
-      >
+      <section class="section section--soft" id="about" aria-labelledby="about-heading" data-snap-section>
         <div class="container">
           <span class="section__float section__float--about" aria-hidden="true" data-parallax-depth="0.06"></span>
           <div class="section__header">
             <p class="section__eyebrow">ABOUT</p>
             <h2 class="section__title" id="about-heading">關於我</h2>
             <p class="section__subtitle">
-              從地球科學出發，我一路把資料分析、互動設計與工程實作串在一起。
-              以下以黏著式敘事整理我的背景、研究、獲獎與帶隊經驗。
+              從地球科學出發，我把資料分析、互動設計與工程實作串在一起。以下用簡潔的段落介紹背景、研究、獲獎與帶隊經驗。
             </p>
           </div>
-          <div class="about-sticky" data-about-sticky>
-            <div class="about-sticky__intro" data-animate="fade-up">
-              <span class="about-sticky__label">Profile</span>
-              <h3 class="about-sticky__title">跨越地球科學與資訊工程的產品創造者</h3>
-              <p class="about-sticky__description">
-                我在國立臺灣師範大學主修地球科學並雙主修資訊工程，
-                從專題研究、資料分析到互動產品開發一路親自實作。外向實事求是的個性讓我
-                擅長協調跨領域團隊，把複雜需求拆解成可以驗證的成果。
+          <div class="about-overview">
+            <div class="about-overview__intro" data-animate="fade-up">
+              <p class="about-overview__eyebrow">Profile</p>
+              <h3 class="about-overview__title">跨越地球科學與資訊工程的產品創造者</h3>
+              <p class="about-overview__summary">
+                我在國立臺灣師範大學主修地球科學並雙主修資訊工程，從專題研究、資料分析到互動產品開發一路親自實作。
+                外向實事求是的個性讓我擅長協調跨領域團隊，把複雜需求拆解成可以驗證的成果。
               </p>
-              <dl class="about-sticky__facts">
+            </div>
+            <div class="about-overview__facts" data-animate="fade-up">
+              <h4 class="about-overview__heading">背景速記</h4>
+              <dl class="about-overview__list">
                 <div>
                   <dt>教育</dt>
                   <dd>國立臺灣師範大學 地球科學系<br />雙主修資訊工程（2021.09 – 現在）</dd>
@@ -168,145 +164,61 @@
                 </div>
               </dl>
             </div>
-            <div class="about-sticky__body">
-              <div class="about-sticky__pin" aria-live="polite">
-                <div class="about-sticky__panels">
-                  <article class="about-panel is-active" data-about-panel="profile" aria-hidden="false">
-                    <header>
-                      <h3>個人簡介</h3>
-                      <p>
-                        我熱愛把研究成果轉化為實際應用，自大二起持續投入跨領域專題。開朗外向且善於表達，
-                        喜歡帶著團隊一起把想法落實，確保每一步都有數據與故事支撐。
-                      </p>
-                    </header>
-                  </article>
-                  <article class="about-panel" data-about-panel="research" aria-hidden="true">
-                    <header>
-                      <h3>專題研究</h3>
-                    </header>
-                    <ul class="about-panel__list">
-                      <li>
-                        <strong>颱風對海洋表層葉綠素 a 影響之研究｜2018.09 – 2021.10</strong><br />
-                        以 MATLAB 分析西北太平洋颱風對藻類數量的影響，獲「美國氣象學會獎」。
-                      </li>
-                      <li>
-                        <strong>Model Selection: Trade-Offs Between Model Size and Predictive Accuracy｜2023.10 – 2024.01</strong><br />
-                        探討模型大小與準確率的平衡，透過超參數調整提升小型模型表現。
-                      </li>
-                    </ul>
-                  </article>
-                  <article class="about-panel" data-about-panel="awards" aria-hidden="true">
-                    <header>
-                      <h3>競賽與獲獎</h3>
-                    </header>
-                    <ul class="about-panel__list">
-                      <li>OpenHCI 2024 人機互動工作坊 <strong>最佳 Demo 獎</strong>（ME_NU 菜單推薦系統）。</li>
-                      <li>Normal Game Jam 2024 <strong>Gameplay 第一名、Overall 第三名</strong>（Show the Sheep）。</li>
-                      <li>師大地科五育獎學金連續 <strong>5</strong> 次獲獎（2022.01 – 2023.09）。</li>
-                    </ul>
-                  </article>
-                  <article class="about-panel" data-about-panel="experience" aria-hidden="true">
-                    <header>
-                      <h3>工作經驗</h3>
-                    </header>
-                    <ul class="about-panel__list">
-                      <li>國立臺灣師範大學智慧運算導向永續發展研究中心 網頁維護總負責人（2023.09 – 現在）。</li>
-                      <li>國立臺灣師範大學地球科學系 網頁維護總負責人（2023.02 – 現在）。</li>
-                      <li>攜曦程式推廣學會 Python 課程助教（2021.09 – 2021.12）。</li>
-                    </ul>
-                  </article>
-                  <article class="about-panel" data-about-panel="projects" aria-hidden="true">
-                    <header>
-                      <h3>專案亮點</h3>
-                    </header>
-                    <ul class="about-panel__list">
-                      <li>動態背光調光系統自行設計硬體與韌體，將成本降至市售方案的 10%。</li>
-                      <li>Your Sky Pylot 平台整合多來源資料並提供互動儀表，讓使用者快速掌握觀星條件。</li>
-                    </ul>
-                  </article>
-                  <article class="about-panel" data-about-panel="leadership" aria-hidden="true">
-                    <header>
-                      <h3>社團與領導</h3>
-                    </header>
-                    <ul class="about-panel__list">
-                      <li>國立臺灣大學慈幼山地服務團利稻家 帶隊總召（2021.09 – 2021.12），領導 30 人籌辦 9 天營隊。</li>
-                      <li>師大地科展 2023 總召（2021.09 – 2021.12），與 Open House 合作規劃科普活動。</li>
-                    </ul>
-                  </article>
-                </div>
-                <div class="about-sticky__media">
-                  <div class="about-media__item is-active" data-about-media="profile" aria-hidden="false">
-                    <span class="about-media__icon" aria-hidden="true">🌱</span>
-                    <p class="about-media__caption">跨領域養成，轉化研究成產品故事</p>
-                  </div>
-                  <div class="about-media__item" data-about-media="research" aria-hidden="true">
-                    <span class="about-media__icon" aria-hidden="true">🔬</span>
-                    <p class="about-media__caption">以資料分析與模型調校累積研究底蘊</p>
-                  </div>
-                  <div class="about-media__item" data-about-media="awards" aria-hidden="true">
-                    <span class="about-media__icon" aria-hidden="true">🏅</span>
-                    <p class="about-media__caption">競賽肯定帶來快速驗證與迭代能力</p>
-                  </div>
-                  <div class="about-media__item" data-about-media="experience" aria-hidden="true">
-                    <span class="about-media__icon" aria-hidden="true">💼</span>
-                    <p class="about-media__caption">維運組織網站與跨部門協作的實戰經驗</p>
-                  </div>
-                  <div class="about-media__item" data-about-media="projects" aria-hidden="true">
-                    <span class="about-media__icon" aria-hidden="true">🛠️</span>
-                    <p class="about-media__caption">從硬體到平台的 MVP 交付與迭代</p>
-                  </div>
-                  <div class="about-media__item" data-about-media="leadership" aria-hidden="true">
-                    <span class="about-media__icon" aria-hidden="true">🤝</span>
-                    <p class="about-media__caption">領導大型活動，培養共創與溝通能力</p>
-                  </div>
-                </div>
-              </div>
-              <div class="about-sticky__timeline" data-animate-group data-animate-interval="160">
-                <article class="about-stage is-active" data-about-stage="profile" data-animate="fade-up">
-                  <span class="about-stage__number">01</span>
-                  <div class="about-stage__content">
-                    <h3>跨域養成</h3>
-                    <p>地科與資工並進，擅長用故事與數據連結跨領域團隊。</p>
-                  </div>
-                </article>
-                <article class="about-stage" data-about-stage="research" data-animate="fade-up">
-                  <span class="about-stage__number">02</span>
-                  <div class="about-stage__content">
-                    <h3>研究實力</h3>
-                    <p>從衛星資料分析到模型調校，持續打磨資料與 AI 能力。</p>
-                  </div>
-                </article>
-                <article class="about-stage" data-about-stage="awards" data-animate="fade-up">
-                  <span class="about-stage__number">03</span>
-                  <div class="about-stage__content">
-                    <h3>競賽成果</h3>
-                    <p>多次獲獎驗證創新實力，也把使用者回饋導入下一版。</p>
-                  </div>
-                </article>
-                <article class="about-stage" data-about-stage="experience" data-animate="fade-up">
-                  <span class="about-stage__number">04</span>
-                  <div class="about-stage__content">
-                    <h3>實務經驗</h3>
-                    <p>長期維運校內大型網站，與跨單位協作完成上線。</p>
-                  </div>
-                </article>
-                <article class="about-stage" data-about-stage="projects" data-animate="fade-up">
-                  <span class="about-stage__number">05</span>
-                  <div class="about-stage__content">
-                    <h3>專案亮點</h3>
-                    <p>打造硬軟整合產品與資料平台，著重體驗與可行性。</p>
-                  </div>
-                </article>
-                <article class="about-stage" data-about-stage="leadership" data-animate="fade-up">
-                  <span class="about-stage__number">06</span>
-                  <div class="about-stage__content">
-                    <h3>領導協作</h3>
-                    <p>策畫營隊與科普活動，訓練決策、溝通與臨場應變。</p>
-                  </div>
-                </article>
-              </div>
-            </div>
           </div>
+          <div class="about-highlights" data-animate-group data-animate-interval="160">
+            <article class="about-card" data-animate="fade-up">
+              <h3 class="about-card__title">個人簡介</h3>
+              <p>
+                我熱愛把研究成果轉化為實際應用，自大二起持續投入跨領域專題。開朗外向且善於表達，喜歡帶著團隊一起把想法落實，
+                確保每一步都有數據與故事支撐。
+              </p>
+            </article>
+            <article class="about-card" data-animate="fade-up">
+              <h3 class="about-card__title">專題研究</h3>
+              <ul class="about-card__list">
+                <li>
+                  <strong>颱風對海洋表層葉綠素 a 影響之研究｜2018.09 – 2021.10</strong><br />
+                  以 MATLAB 分析西北太平洋颱風對藻類數量的影響，獲「美國氣象學會獎」。
+                </li>
+                <li>
+                  <strong>Model Selection: Trade-Offs Between Model Size and Predictive Accuracy｜2023.10 – 2024.01</strong><br />
+                  探討模型大小與準確率的平衡，透過超參數調整提升小型模型表現。
+                </li>
+              </ul>
+            </article>
+            <article class="about-card" data-animate="fade-up">
+              <h3 class="about-card__title">競賽與獲獎</h3>
+              <ul class="about-card__list">
+                <li>OpenHCI 2024 人機互動工作坊 <strong>最佳 Demo 獎</strong>（ME_NU 菜單推薦系統）。</li>
+                <li>Normal Game Jam 2024 <strong>Gameplay 第一名、Overall 第三名</strong>（Show the Sheep）。</li>
+                <li>師大地科五育獎學金連續 <strong>5</strong> 次獲獎（2022.01 – 2023.09）。</li>
+              </ul>
+            </article>
+            <article class="about-card" data-animate="fade-up">
+              <h3 class="about-card__title">工作經驗</h3>
+              <ul class="about-card__list">
+                <li>國立臺灣師範大學智慧運算導向永續發展研究中心 網頁維護總負責人（2023.09 – 現在）。</li>
+                <li>國立臺灣師範大學地球科學系 網頁維護總負責人（2023.02 – 現在）。</li>
+                <li>攜曦程式推廣學會 Python 課程助教（2021.09 – 2021.12）。</li>
+              </ul>
+            </article>
+            <article class="about-card" data-animate="fade-up">
+              <h3 class="about-card__title">專案亮點</h3>
+              <ul class="about-card__list">
+                <li>動態背光調光系統自行設計硬體與韌體，將成本降至市售方案的 10%。</li>
+                <li>Your Sky Pylot 平台整合多來源資料並提供互動儀表，讓使用者快速掌握觀星條件。</li>
+              </ul>
+            </article>
+            <article class="about-card" data-animate="fade-up">
+              <h3 class="about-card__title">社團與領導</h3>
+              <ul class="about-card__list">
+                <li>國立臺灣大學慈幼山地服務團利稻家 帶隊總召（2021.09 – 2021.12），領導 30 人籌辦 9 天營隊。</li>
+                <li>師大地科展 2023 總召（2021.09 – 2021.12），與 Open House 合作規劃科普活動。</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
       <section
         class="section section--layered"
         id="projects"
@@ -842,7 +754,7 @@
           </div>
           <div class="contact__actions">
             <a class="btn btn--primary" href="mailto:patrick@example.com">寄信給我</a>
-            <a class="btn btn--ghost" href="#top">回到最上方</a>
+            <a class="btn btn--ghost" href="#top" data-scroll-top>回到最上方</a>
           </div>
         </div>
       </section>

--- a/script.js
+++ b/script.js
@@ -35,7 +35,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const autoAnimateGroups = [
     [".hero__stats", 120],
-    [".about-sticky__timeline", 160],
+    [".about-highlights", 150],
     [".project-timeline", 140],
     [".project-detail__main", 140],
     [".project-sidebar", 160],
@@ -222,81 +222,6 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
-  const aboutStickyLayouts = document.querySelectorAll("[data-about-sticky]");
-
-  aboutStickyLayouts.forEach((layout) => {
-    const stages = Array.from(layout.querySelectorAll("[data-about-stage]"));
-    const panels = Array.from(layout.querySelectorAll("[data-about-panel]"));
-    const mediaItems = Array.from(layout.querySelectorAll("[data-about-media]"));
-
-    if (!stages.length || !panels.length) {
-      return;
-    }
-
-    let activeId = "";
-
-    const setActiveStage = (id) => {
-      panels.forEach((panel) => {
-        const isMatch = panel.dataset.aboutPanel === id;
-        panel.classList.toggle("is-active", isMatch);
-        panel.setAttribute("aria-hidden", (!isMatch).toString());
-      });
-
-      mediaItems.forEach((item) => {
-        const isMatch = item.dataset.aboutMedia === id;
-        item.classList.toggle("is-active", isMatch);
-        item.setAttribute("aria-hidden", (!isMatch).toString());
-      });
-
-      stages.forEach((stage) => {
-        stage.classList.toggle("is-active", stage.dataset.aboutStage === id);
-      });
-    };
-
-    const updateActiveStage = () => {
-      const viewportHeight = window.innerHeight || 1;
-      const focusLine = viewportHeight * 0.45;
-      let closestStage = stages[0];
-      let smallestDistance = Number.POSITIVE_INFINITY;
-
-      stages.forEach((stage) => {
-        const rect = stage.getBoundingClientRect();
-        const midpoint = rect.top + rect.height / 2;
-        const distance = Math.abs(midpoint - focusLine);
-        if (distance < smallestDistance) {
-          smallestDistance = distance;
-          closestStage = stage;
-        }
-      });
-
-      if (!closestStage) {
-        return;
-      }
-
-      const nextId = closestStage.dataset.aboutStage || "";
-      if (nextId && nextId !== activeId) {
-        activeId = nextId;
-        setActiveStage(activeId);
-      }
-    };
-
-    let ticking = false;
-    const requestUpdate = () => {
-      if (ticking) {
-        return;
-      }
-      ticking = true;
-      requestAnimationFrame(() => {
-        ticking = false;
-        updateActiveStage();
-      });
-    };
-
-    updateActiveStage();
-    window.addEventListener("scroll", requestUpdate, { passive: true });
-    window.addEventListener("resize", requestUpdate);
-  });
-
   const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
   const storedTheme = localStorage.getItem("patrick-theme");
 
@@ -335,6 +260,19 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  const scrollTopLinks = document.querySelectorAll("[data-scroll-top]");
+
+  scrollTopLinks.forEach((link) => {
+    link.addEventListener("click", (event) => {
+      event.preventDefault();
+      scrollToTop();
+    });
+  });
+
   if (backToTop) {
     const toggleBackToTop = () => {
       const shouldShow = window.scrollY > 360;
@@ -344,9 +282,7 @@ document.addEventListener("DOMContentLoaded", () => {
     window.addEventListener("scroll", toggleBackToTop, { passive: true });
     toggleBackToTop();
 
-    backToTop.addEventListener("click", () => {
-      window.scrollTo({ top: 0, behavior: "smooth" });
-    });
+    backToTop.addEventListener("click", scrollToTop);
   }
 
   if (currentYearEl) {

--- a/styles.css
+++ b/styles.css
@@ -810,348 +810,165 @@ body::before {
   overflow: clip;
 }
 
-.about-sticky {
-  position: relative;
+.about-overview {
+  margin-top: clamp(2.4rem, 5vw, 3.6rem);
   display: grid;
-  gap: clamp(3rem, 5vw, 4.8rem);
+  gap: clamp(1.6rem, 3vw, 2.6rem);
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  align-items: start;
 }
 
-.about-sticky::before {
-  content: "";
-  position: absolute;
-  inset: -8%;
-  background: radial-gradient(circle at 20% 0%, rgba(79, 70, 229, 0.18), transparent 55%),
-    radial-gradient(circle at 80% 100%, rgba(56, 189, 248, 0.14), transparent 60%);
-  filter: blur(40px);
-  opacity: 0.6;
-  pointer-events: none;
-  z-index: -1;
-}
-
-.about-sticky__intro {
-  position: relative;
-  padding: clamp(2rem, 2vw + 1.6rem, 2.75rem) clamp(2.2rem, 3vw, 3rem);
-  border-radius: 1.9rem;
-  background: color-mix(in srgb, var(--color-surface-strong) 88%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
-  box-shadow: 0 32px 70px rgba(15, 23, 42, 0.18);
-  backdrop-filter: blur(28px);
+.about-overview__intro,
+.about-overview__facts {
+  padding: clamp(1.6rem, 3.2vw, 2.6rem);
+  border-radius: 1.8rem;
+  background: color-mix(in srgb, var(--color-surface-strong) 95%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 62%, transparent);
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.12);
   display: grid;
-  gap: 1.3rem;
-  overflow: clip;
+  gap: clamp(0.9rem, 2vw, 1.4rem);
 }
 
-.about-sticky__label {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  padding: 0.35rem 0.8rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--color-primary) 26%, transparent);
-  color: #fff;
-  font-size: 0.8rem;
-  letter-spacing: 0.12em;
+.about-overview__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  color: var(--color-primary);
   text-transform: uppercase;
 }
 
-.about-sticky__title {
+.about-overview__title {
   margin: 0;
-  font-size: clamp(2.1rem, 1.4rem + 1.8vw, 2.8rem);
+  font-size: clamp(1.65rem, 2.2vw + 1rem, 2.2rem);
+  line-height: 1.3;
 }
 
-.about-sticky__description {
+.about-overview__summary {
   margin: 0;
   color: var(--color-muted);
-  line-height: 1.8;
-  font-size: clamp(1rem, 0.92rem + 0.28vw, 1.12rem);
+  line-height: 1.75;
 }
 
-.about-sticky__facts {
+.about-overview__heading {
   margin: 0;
+  font-size: 1.1rem;
+}
+
+.about-overview__list {
+  margin: 0;
+  padding: 0;
   display: grid;
   gap: 1.2rem;
 }
 
-.about-sticky__facts div {
+.about-overview__list div {
   display: grid;
-  gap: 0.4rem;
+  gap: 0.35rem;
 }
 
-.about-sticky__facts dt {
-  font-size: 0.82rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--color-muted) 65%, transparent);
-}
-
-.about-sticky__facts dd {
-  margin: 0;
-  color: color-mix(in srgb, var(--color-text) 92%, transparent);
-  line-height: 1.65;
-  font-size: 0.98rem;
-}
-
-.about-sticky__body {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 420px);
-  grid-template-areas: "timeline pin";
-  gap: clamp(2.8rem, 6vw, 5.4rem);
-  align-items: start;
-}
-
-.about-sticky__pin {
-  grid-area: pin;
-  position: sticky;
-  top: clamp(5.6rem, 6vw, 8rem);
-  display: grid;
-  gap: clamp(1.1rem, 1.6vw, 1.8rem);
-  align-self: start;
-}
-
-.about-sticky__panels {
-  position: relative;
-  min-height: clamp(200px, 24vw, 300px);
-}
-
-.about-panel {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  gap: 1.1rem;
-  padding: 0 0.3rem;
-  opacity: 0;
-  transform: translateY(30px);
-  transition: opacity var(--transition), transform var(--transition);
-  pointer-events: none;
-}
-
-.about-panel.is-active {
-  opacity: 1;
-  transform: translateY(0);
-  pointer-events: auto;
-}
-
-.about-panel header h3 {
-  margin: 0 0 0.2rem;
-  font-size: clamp(1.35rem, 1rem + 1vw, 1.9rem);
-  line-height: 1.25;
-}
-.about-panel header p {
-  margin: 0;
-  font-size: clamp(1.02rem, 0.95rem + 0.35vw, 1.15rem);
-  line-height: 1.8;
-  color: color-mix(in srgb, var(--color-text) 94%, transparent);
-}
-
-.about-panel__list {
-  margin: 0;
-  padding-left: 1.2rem;
-  display: grid;
-  gap: 0.65rem;
-  color: color-mix(in srgb, var(--color-text) 94%, transparent);
-  line-height: 1.75;
-}
-
-.about-panel__list strong {
-  color: var(--color-primary);
-  font-weight: 700;
-}
-
-.about-sticky__media {
-  position: relative;
-  min-height: clamp(200px, 24vw, 300px);
-  margin-bottom: 0.5rem;
-  border-radius: 1.9rem;
-  background: linear-gradient(160deg, color-mix(in srgb, var(--color-surface-strong) 95%, transparent),
-      color-mix(in srgb, var(--color-primary) 18%, transparent));
-  border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
-  overflow: hidden;
-  box-shadow: 0 26px 60px rgba(15, 23, 42, 0.2);
-}
-
-.about-media__item {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  align-content: center;
-  justify-items: center;
-  gap: 1.1rem;
-  padding: clamp(2rem, 3vw, 2.8rem);
-  opacity: 0;
-  transform: translateY(40px) scale(0.96);
-  transition: opacity var(--transition), transform var(--transition);
-  color: color-mix(in srgb, var(--color-text) 96%, transparent);
-}
-
-.about-media__item.is-active {
-  opacity: 1;
-  transform: translateY(0) scale(1);
-}
-
-.about-media__icon {
-  display: grid;
-  place-items: center;
-  width: clamp(3.8rem, 3.2rem + 1.8vw, 4.4rem);
-  height: clamp(3.8rem, 3.2rem + 1.8vw, 4.4rem);
-  border-radius: 1.3rem;
-  background: linear-gradient(145deg, rgba(79, 70, 229, 0.9), rgba(236, 72, 153, 0.78));
-  font-size: clamp(1.8rem, 1.5rem + 0.8vw, 2.2rem);
-  color: #fff;
-  box-shadow: 0 18px 38px rgba(79, 70, 229, 0.32);
-}
-
-.about-media__caption {
-  margin: 0;
-  max-width: 18ch;
-  text-align: center;
-  line-height: 1.6;
-}
-
-.about-sticky__timeline {
-  grid-area: timeline;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: clamp(2rem, 4vw, 3rem);
-  padding-block: 1rem clamp(5rem, 8vw, 6rem);
-  overflow: clip;
-}
-
-.about-sticky__timeline::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: clamp(1.4rem, 2vw, 2.1rem);
-  width: 2px;
-  background: color-mix(in srgb, var(--color-border) 70%, transparent);
-}
-
-.about-stage {
-  position: relative;
-  min-height: clamp(280px, 34vh, 520px);
-  padding-left: clamp(3.5rem, 3vw + 2.6rem, 4.6rem);
-  display: grid;
-  align-content: center;
-  gap: 0.9rem;
-  color: color-mix(in srgb, var(--color-muted) 80%, transparent);
-}
-
-.about-stage::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: clamp(1.2rem, 2vw, 1.9rem);
-  width: 2px;
-  height: 100%;
-  background: linear-gradient(180deg, color-mix(in srgb, var(--color-primary) 45%, transparent), transparent 82%);
-  opacity: 0;
-  transition: opacity var(--transition);
-}
-
-.about-stage.is-active::before {
-  opacity: 1;
-}
-
-.about-stage.is-active {
-  color: color-mix(in srgb, var(--color-text) 92%, transparent);
-}
-
-.about-stage__number {
-  position: absolute;
-  top: 1.1rem;
-  left: 0;
-  transform: none;
-  font-size: 1.2rem;
+.about-overview__list dt {
   font-weight: 600;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--color-muted) 60%, transparent);
-}
-
-.about-stage.is-active .about-stage__number {
   color: var(--color-primary);
 }
 
-.about-stage__content h3 {
+.about-overview__list dd {
   margin: 0;
-  font-size: clamp(1.35rem, 1.15rem + 0.8vw, 1.8rem);
-}
-
-.about-stage__content p {
-  margin: 0;
-  max-width: 42ch;
+  color: var(--color-muted);
   line-height: 1.7;
 }
 
+.about-highlights {
+  margin-top: clamp(2.8rem, 5vw, 4.4rem);
+  display: grid;
+  gap: clamp(1.4rem, 3vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.about-card {
+  padding: clamp(1.6rem, 3vw, 2.4rem);
+  border-radius: 1.6rem;
+  background: color-mix(in srgb, var(--color-surface-strong) 96%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 58%, transparent);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 0.9rem;
+}
+
+.about-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.about-card p {
+  margin: 0;
+  color: var(--color-muted);
+  line-height: 1.75;
+}
+
+.about-card__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.about-card__list li {
+  position: relative;
+  padding-left: 1.2rem;
+  line-height: 1.7;
+  color: var(--color-muted);
+}
+
+.about-card__list li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.6rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--color-primary);
+  opacity: 0.45;
+}
+
+body.theme-dark .about-overview__intro,
+body.theme-dark .about-overview__facts,
+body.theme-dark .about-card {
+  background: color-mix(in srgb, var(--color-surface-strong) 88%, transparent);
+  border-color: color-mix(in srgb, var(--color-border) 40%, transparent);
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.45);
+}
+
 @media (max-width: 1024px) {
-  .about-sticky__body {
+  .about-overview {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-areas:
-      "pin"
-      "timeline";
-  }
-
-  .about-sticky__pin {
-    position: sticky;
-    top: clamp(5rem, 7vw, 7rem);
-  }
-
-  .about-sticky__timeline {
-    padding-top: clamp(2rem, 6vw, 3rem);
-  }
-
-  .about-sticky__timeline::before {
-    left: 1rem;
-  }
-
-  .about-stage {
-    padding-left: 3.4rem;
   }
 }
 
 @media (max-width: 720px) {
-  .section--sticky {
-    padding-block: 4.8rem 7.2rem;
+  .about-overview__intro,
+  .about-overview__facts {
+    padding: clamp(1.4rem, 4vw, 2rem);
   }
 
-  .about-sticky {
-    gap: 2.4rem;
-  }
-
-  .about-sticky__intro {
-    padding: 1.6rem 1.9rem;
-  }
-
-  .about-sticky__timeline {
-    padding-block: 1rem 6rem;
-  }
-
-  .about-stage {
-    min-height: clamp(220px, 42vh, 360px);
-  }
-
-  .about-sticky__media {
-    min-height: clamp(220px, 60vw, 320px);
+  .about-highlights {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
 @media (max-width: 560px) {
-  .about-stage {
-    min-height: clamp(200px, 38vh, 320px);
-    padding-left: 2.6rem;
+  .about-overview {
+    margin-top: 2rem;
   }
 
-  .about-stage__number {
-    font-size: 1rem;
+  .about-overview__title {
+    font-size: clamp(1.4rem, 5vw, 1.8rem);
   }
 
-  .about-sticky__timeline::before {
-    left: 0.85rem;
+  .about-card {
+    padding: clamp(1.3rem, 5vw, 1.8rem);
   }
 }
-
-
 .filter-controls {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- replace the parallax About layout with a straightforward overview and highlight card grid so the page scrolls normally
- add new About overview/highlight styles and responsive tweaks while removing the parallax-specific CSS
- update the animation helper to target the new About highlight grid
- ensure the contact section “回到最上方” button triggers the same smooth scroll-to-top behavior as the floating shortcut

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e21f1fa184832798bd1de87cdb435f