### PR TITLE
Add project gallery tiles with filter support

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,32 +128,28 @@
         </div>
       </section>
 
-      <section
-        class="section section--soft section--sticky"
-        id="about"
-        aria-labelledby="about-heading"
-        data-snap-section
-      >
+      <section class="section section--soft" id="about" aria-labelledby="about-heading" data-snap-section>
         <div class="container">
           <span class="section__float section__float--about" aria-hidden="true" data-parallax-depth="0.06"></span>
           <div class="section__header">
             <p class="section__eyebrow">ABOUT</p>
             <h2 class="section__title" id="about-heading">關於我</h2>
             <p class="section__subtitle">
-              從地球科學出發，我一路把資料分析、互動設計與工程實作串在一起。
-              以下以黏著式敘事整理我的背景、研究、獲獎與帶隊經驗。
+              從地球科學出發，我把資料分析、互動設計與工程實作串在一起。以下用簡潔的段落介紹背景、研究、獲獎與帶隊經驗。
             </p>
           </div>
-          <div class="about-sticky" data-about-sticky>
-            <div class="about-sticky__intro" data-animate="fade-up">
-              <span class="about-sticky__label">Profile</span>
-              <h3 class="about-sticky__title">跨越地球科學與資訊工程的產品創造者</h3>
-              <p class="about-sticky__description">
-                我在國立臺灣師範大學主修地球科學並雙主修資訊工程，
-                從專題研究、資料分析到互動產品開發一路親自實作。外向實事求是的個性讓我
-                擅長協調跨領域團隊，把複雜需求拆解成可以驗證的成果。
+          <div class="about-overview">
+            <div class="about-overview__intro" data-animate="fade-up">
+              <p class="about-overview__eyebrow">Profile</p>
+              <h3 class="about-overview__title">跨越地球科學與資訊工程的產品創造者</h3>
+              <p class="about-overview__summary">
+                我在國立臺灣師範大學主修地球科學並雙主修資訊工程，從專題研究、資料分析到互動產品開發一路親自實作。
+                外向實事求是的個性讓我擅長協調跨領域團隊，把複雜需求拆解成可以驗證的成果。
               </p>
-              <dl class="about-sticky__facts">
+            </div>
+            <div class="about-overview__facts" data-animate="fade-up">
+              <h4 class="about-overview__heading">背景速記</h4>
+              <dl class="about-overview__list">
                 <div>
                   <dt>教育</dt>
                   <dd>國立臺灣師範大學 地球科學系<br />雙主修資訊工程（2021.09 – 現在）</dd>
@@ -168,145 +164,61 @@
                 </div>
               </dl>
             </div>
-            <div class="about-sticky__body">
-              <div class="about-sticky__pin" aria-live="polite">
-                <div class="about-sticky__panels">
-                  <article class="about-panel is-active" data-about-panel="profile" aria-hidden="false">
-                    <header>
-                      <h3>個人簡介</h3>
-                      <p>
-                        我熱愛把研究成果轉化為實際應用，自大二起持續投入跨領域專題。開朗外向且善於表達，
-                        喜歡帶著團隊一起把想法落實，確保每一步都有數據與故事支撐。
-                      </p>
-                    </header>
-                  </article>
-                  <article class="about-panel" data-about-panel="research" aria-hidden="true">
-                    <header>
-                      <h3>專題研究</h3>
-                    </header>
-                    <ul class="about-panel__list">
-                      <li>
-                        <strong>颱風對海洋表層葉綠素 a 影響之研究｜2018.09 – 2021.10</strong><br />
-                        以 MATLAB 分析西北太平洋颱風對藻類數量的影響，獲「美國氣象學會獎」。
-                      </li>
-                      <li>
-                        <strong>Model Selection: Trade-Offs Between Model Size and Predictive Accuracy｜2023.10 – 2024.01</strong><br />
-                        探討模型大小與準確率的平衡，透過超參數調整提升小型模型表現。
-                      </li>
-                    </ul>
-                  </article>
-                  <article class="about-panel" data-about-panel="awards" aria-hidden="true">
-                    <header>
-                      <h3>競賽與獲獎</h3>
-                    </header>
-                    <ul class="about-panel__list">
-                      <li>OpenHCI 2024 人機互動工作坊 <strong>最佳 Demo 獎</strong>（ME_NU 菜單推薦系統）。</li>
-                      <li>Normal Game Jam 2024 <strong>Gameplay 第一名、Overall 第三名</strong>（Show the Sheep）。</li>
-                      <li>師大地科五育獎學金連續 <strong>5</strong> 次獲獎（2022.01 – 2023.09）。</li>
-                    </ul>
-                  </article>
-                  <article class="about-panel" data-about-panel="experience" aria-hidden="true">
-                    <header>
-                      <h3>工作經驗</h3>
-                    </header>
-                    <ul class="about-panel__list">
-                      <li>國立臺灣師範大學智慧運算導向永續發展研究中心 網頁維護總負責人（2023.09 – 現在）。</li>
-                      <li>國立臺灣師範大學地球科學系 網頁維護總負責人（2023.02 – 現在）。</li>
-                      <li>攜曦程式推廣學會 Python 課程助教（2021.09 – 2021.12）。</li>
-                    </ul>
-                  </article>
-                  <article class="about-panel" data-about-panel="projects" aria-hidden="true">
-                    <header>
-                      <h3>專案亮點</h3>
-                    </header>
-                    <ul class="about-panel__list">
-                      <li>動態背光調光系統自行設計硬體與韌體，將成本降至市售方案的 10%。</li>
-                      <li>Your Sky Pylot 平台整合多來源資料並提供互動儀表，讓使用者快速掌握觀星條件。</li>
-                    </ul>
-                  </article>
-                  <article class="about-panel" data-about-panel="leadership" aria-hidden="true">
-                    <header>
-                      <h3>社團與領導</h3>
-                    </header>
-                    <ul class="about-panel__list">
-                      <li>國立臺灣大學慈幼山地服務團利稻家 帶隊總召（2021.09 – 2021.12），領導 30 人籌辦 9 天營隊。</li>
-                      <li>師大地科展 2023 總召（2021.09 – 2021.12），與 Open House 合作規劃科普活動。</li>
-                    </ul>
-                  </article>
-                </div>
-                <div class="about-sticky__media">
-                  <div class="about-media__item is-active" data-about-media="profile" aria-hidden="false">
-                    <span class="about-media__icon" aria-hidden="true">🌱</span>
-                    <p class="about-media__caption">跨領域養成，轉化研究成產品故事</p>
-                  </div>
-                  <div class="about-media__item" data-about-media="research" aria-hidden="true">
-                    <span class="about-media__icon" aria-hidden="true">🔬</span>
-                    <p class="about-media__caption">以資料分析與模型調校累積研究底蘊</p>
-                  </div>
-                  <div class="about-media__item" data-about-media="awards" aria-hidden="true">
-                    <span class="about-media__icon" aria-hidden="true">🏅</span>
-                    <p class="about-media__caption">競賽肯定帶來快速驗證與迭代能力</p>
-                  </div>
-                  <div class="about-media__item" data-about-media="experience" aria-hidden="true">
-                    <span class="about-media__icon" aria-hidden="true">💼</span>
-                    <p class="about-media__caption">維運組織網站與跨部門協作的實戰經驗</p>
-                  </div>
-                  <div class="about-media__item" data-about-media="projects" aria-hidden="true">
-                    <span class="about-media__icon" aria-hidden="true">🛠️</span>
-                    <p class="about-media__caption">從硬體到平台的 MVP 交付與迭代</p>
-                  </div>
-                  <div class="about-media__item" data-about-media="leadership" aria-hidden="true">
-                    <span class="about-media__icon" aria-hidden="true">🤝</span>
-                    <p class="about-media__caption">領導大型活動，培養共創與溝通能力</p>
-                  </div>
-                </div>
-              </div>
-              <div class="about-sticky__timeline" data-animate-group data-animate-interval="160">
-                <article class="about-stage is-active" data-about-stage="profile" data-animate="fade-up">
-                  <span class="about-stage__number">01</span>
-                  <div class="about-stage__content">
-                    <h3>跨域養成</h3>
-                    <p>地科與資工並進，擅長用故事與數據連結跨領域團隊。</p>
-                  </div>
-                </article>
-                <article class="about-stage" data-about-stage="research" data-animate="fade-up">
-                  <span class="about-stage__number">02</span>
-                  <div class="about-stage__content">
-                    <h3>研究實力</h3>
-                    <p>從衛星資料分析到模型調校，持續打磨資料與 AI 能力。</p>
-                  </div>
-                </article>
-                <article class="about-stage" data-about-stage="awards" data-animate="fade-up">
-                  <span class="about-stage__number">03</span>
-                  <div class="about-stage__content">
-                    <h3>競賽成果</h3>
-                    <p>多次獲獎驗證創新實力，也把使用者回饋導入下一版。</p>
-                  </div>
-                </article>
-                <article class="about-stage" data-about-stage="experience" data-animate="fade-up">
-                  <span class="about-stage__number">04</span>
-                  <div class="about-stage__content">
-                    <h3>實務經驗</h3>
-                    <p>長期維運校內大型網站，與跨單位協作完成上線。</p>
-                  </div>
-                </article>
-                <article class="about-stage" data-about-stage="projects" data-animate="fade-up">
-                  <span class="about-stage__number">05</span>
-                  <div class="about-stage__content">
-                    <h3>專案亮點</h3>
-                    <p>打造硬軟整合產品與資料平台，著重體驗與可行性。</p>
-                  </div>
-                </article>
-                <article class="about-stage" data-about-stage="leadership" data-animate="fade-up">
-                  <span class="about-stage__number">06</span>
-                  <div class="about-stage__content">
-                    <h3>領導協作</h3>
-                    <p>策畫營隊與科普活動，訓練決策、溝通與臨場應變。</p>
-                  </div>
-                </article>
-              </div>
-            </div>
           </div>
+          <div class="about-highlights" data-animate-group data-animate-interval="160">
+            <article class="about-card" data-animate="fade-up">
+              <h3 class="about-card__title">個人簡介</h3>
+              <p>
+                我熱愛把研究成果轉化為實際應用，自大二起持續投入跨領域專題。開朗外向且善於表達，喜歡帶著團隊一起把想法落實，
+                確保每一步都有數據與故事支撐。
+              </p>
+            </article>
+            <article class="about-card" data-animate="fade-up">
+              <h3 class="about-card__title">專題研究</h3>
+              <ul class="about-card__list">
+                <li>
+                  <strong>颱風對海洋表層葉綠素 a 影響之研究｜2018.09 – 2021.10</strong><br />
+                  以 MATLAB 分析西北太平洋颱風對藻類數量的影響，獲「美國氣象學會獎」。
+                </li>
+                <li>
+                  <strong>Model Selection: Trade-Offs Between Model Size and Predictive Accuracy｜2023.10 – 2024.01</strong><br />
+                  探討模型大小與準確率的平衡，透過超參數調整提升小型模型表現。
+                </li>
+              </ul>
+            </article>
+            <article class="about-card" data-animate="fade-up">
+              <h3 class="about-card__title">競賽與獲獎</h3>
+              <ul class="about-card__list">
+                <li>OpenHCI 2024 人機互動工作坊 <strong>最佳 Demo 獎</strong>（ME_NU 菜單推薦系統）。</li>
+                <li>Normal Game Jam 2024 <strong>Gameplay 第一名、Overall 第三名</strong>（Show the Sheep）。</li>
+                <li>師大地科五育獎學金連續 <strong>5</strong> 次獲獎（2022.01 – 2023.09）。</li>
+              </ul>
+            </article>
+            <article class="about-card" data-animate="fade-up">
+              <h3 class="about-card__title">工作經驗</h3>
+              <ul class="about-card__list">
+                <li>國立臺灣師範大學智慧運算導向永續發展研究中心 網頁維護總負責人（2023.09 – 現在）。</li>
+                <li>國立臺灣師範大學地球科學系 網頁維護總負責人（2023.02 – 現在）。</li>
+                <li>攜曦程式推廣學會 Python 課程助教（2021.09 – 2021.12）。</li>
+              </ul>
+            </article>
+            <article class="about-card" data-animate="fade-up">
+              <h3 class="about-card__title">專案亮點</h3>
+              <ul class="about-card__list">
+                <li>動態背光調光系統自行設計硬體與韌體，將成本降至市售方案的 10%。</li>
+                <li>Your Sky Pylot 平台整合多來源資料並提供互動儀表，讓使用者快速掌握觀星條件。</li>
+              </ul>
+            </article>
+            <article class="about-card" data-animate="fade-up">
+              <h3 class="about-card__title">社團與領導</h3>
+              <ul class="about-card__list">
+                <li>國立臺灣大學慈幼山地服務團利稻家 帶隊總召（2021.09 – 2021.12），領導 30 人籌辦 9 天營隊。</li>
+                <li>師大地科展 2023 總召（2021.09 – 2021.12），與 Open House 合作規劃科普活動。</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
       <section
         class="section section--layered"
         id="projects"
@@ -334,495 +246,238 @@
             <button class="filter-btn" type="button" data-filter="data">資料平台</button>
           </div>
 
-          <div class="project-timeline" data-animate-group data-animate-interval="140">
+          <div class="project-gallery" data-animate-group data-animate-interval="140">
             <a
-              class="project-card"
-              data-tags="ai automation"
-              id="email-summarizer"
-              href="projects/email-summarizer.html"
-              style="--accent: #6f7bff; --accent-soft: rgba(111, 123, 255, 0.2); --accent-glow: rgba(111, 123, 255, 0.45); --project-image: radial-gradient(circle at 30% 20%, rgba(255,255,255,0.8), transparent 62%), radial-gradient(circle at 80% 70%, rgba(111,123,255,0.55), transparent 55%);"
-            >
-              <span class="project-card__rail" aria-hidden="true"></span>
-              <div class="project-card__timeline">
-                <time class="project-card__time" datetime="2024-03">2024.03</time>
-                <span class="project-card__tag">AI / 自動化</span>
-              </div>
-              <div class="project-card__body">
-                <div class="project-card__content">
-                  <div class="project-card__header">
-                    <div class="project-card__heading">
-                      <h3 class="project-card__title">AI 智慧郵件摘要管理系統</h3>
-                    </div>
-                    <span class="project-card__meta">獨立完成｜Python・OpenAI・IMAP</span>
-                  </div>
-                  <p>
-                    每日自動抓取多個信箱，使用 GPT 生成分類摘要，並以 Markdown/HTML 報告寄送，
-                    讓團隊在早晨即可掌握「需回覆」與「優先通知」等重點郵件。
-                  </p>
-                  <ul class="project-card__highlights">
-                    <li>整合 IMAP 抓取、Yagmail 推送與環境變數管理，打造全自動流程。</li>
-                    <li>AI 判斷郵件重要性、回覆需求與類別，避免遺漏關鍵資訊。</li>
-                    <li>支援多位收件人與自訂分類，適合個人與團隊協作。</li>
-                  </ul>
-                  <span class="project-card__cta">查看完整案例</span>
-                  </div>
-                <div class="project-card__media" aria-hidden="true">
-                  <span class="project-card__thumb"></span>
-                </div>
-              </div>
-            </a>
-
-            <a
-              class="project-card"
-              data-tags="ai web"
-              id="menu-llm"
-              href="projects/menu-llm.html"
-              style="--accent: #ff7a90; --accent-soft: rgba(255, 122, 144, 0.22); --accent-glow: rgba(255, 122, 144, 0.42); --project-image: conic-gradient(from 140deg at 70% 30%, rgba(255,213,132,0.7), transparent 65%), radial-gradient(circle at 40% 70%, rgba(255,122,144,0.55), transparent 58%);"
-            >
-              <span class="project-card__rail" aria-hidden="true"></span>
-              <div class="project-card__timeline">
-                <time class="project-card__time" datetime="2024-02">2024.02</time>
-                <span class="project-card__tag">AI + Web</span>
-              </div>
-              <div class="project-card__body">
-                <div class="project-card__content">
-                  <div class="project-card__header">
-                    <div class="project-card__heading">
-                      <h3 class="project-card__title">ME_NU LLM 菜單推薦系統</h3>
-                      <span class="project-card__badge">🏆 OpenHCI 2024 最佳 Demo</span>
-                    </div>
-                    <span class="project-card__meta">9 人團隊｜LangChain・LINE Bot・Web App</span>
-                  </div>
-                  <p>
-                    結合 ChatGPT API 的個性化點餐助手，整合菜單、用戶偏好與評論，
-                    讓使用者快速獲得情境化餐點建議並與多角色 AI 對話。
-                  </p>
-                  <ul class="project-card__highlights">
-                    <li>於 OpenHCI 2024 獲得最佳 Demo 獎，現場超過 200 名參與者體驗。</li>
-                    <li>串接 LangChain 與 ChatGPT API，設計多角色 Prompt 提升互動體驗。</li>
-                    <li>建立資料處理流程整合菜單與網路評價，提高推薦精準度。</li>
-                    <li>優化回應效能，於 LINE Bot 與 Web 雙平台提供即時建議。</li>
-                  </ul>
-                  <span class="project-card__cta">查看完整案例</span>
-                  </div>
-                <div class="project-card__media" aria-hidden="true">
-                  <span class="project-card__thumb"></span>
-                </div>
-              </div>
-            </a>
-
-            <a
-              class="project-card"
-              data-tags="ai web"
-              id="pdf-langchain"
-              href="projects/pdf-langchain.html"
-              style="--accent: #65d0ff; --accent-soft: rgba(101, 208, 255, 0.24); --accent-glow: rgba(101, 208, 255, 0.46); --project-image: radial-gradient(circle at 72% 24%, rgba(255,255,255,0.85), transparent 60%), radial-gradient(circle at 30% 80%, rgba(101,208,255,0.6), transparent 55%);"
-            >
-              <span class="project-card__rail" aria-hidden="true"></span>
-              <div class="project-card__timeline">
-                <time class="project-card__time" datetime="2023-12">2023.12</time>
-                <span class="project-card__tag">AI / 教育</span>
-              </div>
-              <div class="project-card__body">
-                <div class="project-card__content">
-                  <div class="project-card__header">
-                    <div class="project-card__heading">
-                      <h3 class="project-card__title">PDF＋LangChain 教案互動助教</h3>
-                    </div>
-                    <span class="project-card__meta">15 人團隊｜LangChain・Streamlit・OpenAI</span>
-                  </div>
-                  <p>
-                    為教師打造的教案助教系統，可匯入 PDF/文字檔，透過 RAG 與 Prompt Engineering
-                    引導 AI 回答課堂問題，並記錄互動歷程以調整教學策略。
-                  </p>
-                  <ul class="project-card__highlights">
-                    <li>負責後端 LLM 串接與檔案解析流程，建立可客製的訓練管線。</li>
-                    <li>支援即時修正與角色化回答，降低教師回應負擔。</li>
-                    <li>以 Streamlit 打造直覺界面，快速導入課程使用情境。</li>
-                  </ul>
-                  <span class="project-card__cta">查看完整案例</span>
-                  </div>
-                <div class="project-card__media" aria-hidden="true">
-                  <span class="project-card__thumb"></span>
-                </div>
-              </div>
-            </a>
-
-            <a
-              class="project-card"
-              data-tags="mobile ai"
-              id="aincome"
-              href="projects/aincome.html"
-              style="--accent: #ff9f6e; --accent-soft: rgba(255, 159, 110, 0.22); --accent-glow: rgba(255, 159, 110, 0.4); --project-image: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.85), transparent 60%), conic-gradient(from 220deg at 70% 70%, rgba(255,159,110,0.55), transparent 55%);"
-            >
-              <span class="project-card__rail" aria-hidden="true"></span>
-              <div class="project-card__timeline">
-                <time class="project-card__time" datetime="2023-11">2023.11</time>
-                <span class="project-card__tag">行動應用</span>
-              </div>
-              <div class="project-card__body">
-                <div class="project-card__content">
-                  <div class="project-card__header">
-                    <div class="project-card__heading">
-                      <h3 class="project-card__title">AIncome 智慧記帳 App</h3>
-                    </div>
-                    <span class="project-card__meta">獨立完成｜SwiftUI・OpenAI・App Intents</span>
-                  </div>
-                  <p>
-                    主打自然語言記帳與互動圖表的 iOS 應用。透過 GPT 解析輸入內容，
-                    自動建立分類、店家、日期等欄位，並提供圓餅圖與統計卡片洞察支出。
-                  </p>
-                  <ul class="project-card__highlights">
-                    <li>支援 Siri 捷徑語音記帳與多頁籤介面，提升輸入效率。</li>
-                    <li>以馬卡龍色系與動畫設計打造愉悅的理財體驗。</li>
-                    <li>資料儲存於本地並支援 CSV 匯出，兼顧隱私與備份需求。</li>
-                  </ul>
-                  <span class="project-card__cta">查看完整案例</span>
-                  </div>
-                <div class="project-card__media" aria-hidden="true">
-                  <span class="project-card__thumb"></span>
-                </div>
-              </div>
-            </a>
-
-            <a
-              class="project-card"
-              data-tags="mobile ai"
-              id="stockmatch"
-              href="projects/stockmatch.html"
-              style="--accent: #7d8bff; --accent-soft: rgba(125, 139, 255, 0.22); --accent-glow: rgba(125, 139, 255, 0.42); --project-image: radial-gradient(circle at 65% 35%, rgba(255,255,255,0.78), transparent 60%), radial-gradient(circle at 28% 78%, rgba(125,139,255,0.6), transparent 58%);"
-            >
-              <span class="project-card__rail" aria-hidden="true"></span>
-              <div class="project-card__timeline">
-                <time class="project-card__time" datetime="2023-09">2023.09</time>
-                <span class="project-card__tag">行動應用</span>
-              </div>
-              <div class="project-card__body">
-                <div class="project-card__content">
-                  <div class="project-card__header">
-                    <div class="project-card__heading">
-                      <h3 class="project-card__title">StockMatch 股票配對平台</h3>
-                      <span class="project-card__badge">🏆 Hack to Top 雋寬特別獎</span>
-                    </div>
-                    <span class="project-card__meta">4 人團隊｜SwiftUI・Firebase・OpenAI</span>
-                  </div>
-                  <p>
-                    將投資推薦融入 Tinder 式滑卡互動，結合 GPT 企業角色對話與 Finnhub 即時資料，
-                    讓新手能以遊戲化方式認識股票並管理偏好。
-                  </p>
-                  <ul class="project-card__highlights">
-                    <li>打造股票滑卡推薦與 GPT 企業代表聊天，提升投資理解度。</li>
-                    <li>整合 Firebase 登入與 UserDefaults 儲存個人化偏好。</li>
-                    <li>專案獲得 Hack to Top 競賽雋寬特別獎肯定。</li>
-                  </ul>
-                  <span class="project-card__cta">查看完整案例</span>
-                  </div>
-                <div class="project-card__media" aria-hidden="true">
-                  <span class="project-card__thumb"></span>
-                </div>
-              </div>
-            </a>
-
-            <a
-              class="project-card"
-              data-tags="mobile ai"
-              id="chatwithgpt"
-              href="projects/chatwithgpt.html"
-              style="--accent: #60d8c6; --accent-soft: rgba(96, 216, 198, 0.22); --accent-glow: rgba(96, 216, 198, 0.4); --project-image: conic-gradient(from 120deg at 30% 50%, rgba(96,216,198,0.55), transparent 65%), radial-gradient(circle at 70% 30%, rgba(255,255,255,0.8), transparent 60%);"
-            >
-              <span class="project-card__rail" aria-hidden="true"></span>
-              <div class="project-card__timeline">
-                <time class="project-card__time" datetime="2023-08">2023.08</time>
-                <span class="project-card__tag">行動應用</span>
-              </div>
-              <div class="project-card__body">
-                <div class="project-card__content">
-                  <div class="project-card__header">
-                    <div class="project-card__heading">
-                      <h3 class="project-card__title">ChatWithGPT 群組聊天 App</h3>
-                    </div>
-                    <span class="project-card__meta">獨立完成｜SwiftUI・Firebase・GPT</span>
-                  </div>
-                  <p>
-                    將即時通訊與智慧助理結合，提供滑動回覆、表情反應與訊息標記等細緻互動，
-                    並由 GPT 根據歷史脈絡回應，讓群組協作更有效率。
-                  </p>
-                  <ul class="project-card__highlights">
-                    <li>利用 Firestore 實現即時同步與離線快取，支援大量訊息。</li>
-                    <li>自訂提及判斷、懶載入與推播通知優化群聊體驗。</li>
-                    <li>完整好友與聊天室管理，含釘選、權限與訊息回收。</li>
-                  </ul>
-                  <span class="project-card__cta">查看完整案例</span>
-                  </div>
-                <div class="project-card__media" aria-hidden="true">
-                  <span class="project-card__thumb"></span>
-                </div>
-              </div>
-            </a>
-
-            <a
-              class="project-card"
-              data-tags="ai web"
-              id="emotion-journal"
-              href="projects/emotion-journal.html"
-              style="--accent: #ff7fd6; --accent-soft: rgba(255, 127, 214, 0.22); --accent-glow: rgba(255, 127, 214, 0.42); --project-image: radial-gradient(circle at 70% 35%, rgba(255,255,255,0.82), transparent 62%), radial-gradient(circle at 28% 76%, rgba(255,127,214,0.6), transparent 55%);"
-            >
-              <span class="project-card__rail" aria-hidden="true"></span>
-              <div class="project-card__timeline">
-                <time class="project-card__time" datetime="2023-07">2023.07</time>
-                <span class="project-card__tag">AI / Web</span>
-              </div>
-              <div class="project-card__body">
-                <div class="project-card__content">
-                  <div class="project-card__header">
-                    <div class="project-card__heading">
-                      <h3 class="project-card__title">智慧情緒日記與分析平台</h3>
-                    </div>
-                    <span class="project-card__meta">獨立完成｜Streamlit・GPT-4-turbo・GCP</span>
-                  </div>
-                  <p>
-                    利用 GPT-4-turbo 解析日記內容，提供情緒標註、CBT 建議與鼓勵回饋，
-                    並結合快樂膠囊、回饋與帳號管理打造安全的心理健康助手。
-                  </p>
-                  <ul class="project-card__highlights">
-                    <li>自動產生情緒百分比與 CBT 分析，協助使用者理解自我狀態。</li>
-                    <li>整合 GCP 儲存與 bcrypt 加密，兼顧資料安全與跨裝置同步。</li>
-                    <li>動態背景、提示引導與回饋機制讓日記撰寫更具儀式感。</li>
-                  </ul>
-                  <span class="project-card__cta">查看完整案例</span>
-                  </div>
-                <div class="project-card__media" aria-hidden="true">
-                  <span class="project-card__thumb"></span>
-                </div>
-              </div>
-            </a>
-
-            <a
-              class="project-card"
+              class="project-tile"
+              href="#"
               data-tags="web ai"
-              id="campus-safety"
-              href="projects/campus-safety.html"
-              style="--accent: #5f9bff; --accent-soft: rgba(95, 155, 255, 0.22); --accent-glow: rgba(95, 155, 255, 0.4); --project-image: conic-gradient(from 200deg at 70% 30%, rgba(95,155,255,0.55), transparent 60%), radial-gradient(circle at 30% 70%, rgba(255,255,255,0.85), transparent 60%);"
+              data-animate="panel"
+              aria-label="Project 01"
             >
-              <span class="project-card__rail" aria-hidden="true"></span>
-              <div class="project-card__timeline">
-                <time class="project-card__time" datetime="2023-06">2023.06</time>
-                <span class="project-card__tag">Web</span>
-              </div>
-              <div class="project-card__body">
-                <div class="project-card__content">
-                  <div class="project-card__header">
-                    <div class="project-card__heading">
-                      <h3 class="project-card__title">校園安全守護站</h3>
-                    </div>
-                    <span class="project-card__meta">獨立完成｜HTML・CSS・JavaScript</span>
-                  </div>
-                  <p>
-                    以純前端技術打造的互動式文章平台，支援 Markdown 載入、分類篩選、滾動動畫與主題切換，
-                    作為無伺服器環境也能運作的閱讀體驗框架。
-                  </p>
-                  <ul class="project-card__highlights">
-                    <li>規劃文章載入、標籤篩選與日期排序的同步狀態管理。</li>
-                    <li>利用 IntersectionObserver 與 color-mix() 提升滾動動畫與主題轉換質感。</li>
-                    <li>提供回頂端、進度條與 FAB 操作，打造 SPA 式流暢體驗。</li>
-                  </ul>
-                  <span class="project-card__cta">查看完整案例</span>
-                  </div>
-                <div class="project-card__media" aria-hidden="true">
-                  <span class="project-card__thumb"></span>
-                </div>
+              <figure class="project-tile__media">
+                <img
+                  src="https://picsum.photos/seed/project-01/600/750"
+                  alt="Project 01 專案預覽圖（placeholder）"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+              <div class="project-tile__overlay">
+                <span class="project-tile__title">Project 01</span>
               </div>
             </a>
-
             <a
-              class="project-card"
-              data-tags="web data"
-              id="cpbl-platform"
-              href="projects/cpbl-platform.html"
-              style="--accent: #9a8cff; --accent-soft: rgba(154, 140, 255, 0.22); --accent-glow: rgba(154, 140, 255, 0.42); --project-image: radial-gradient(circle at 68% 36%, rgba(255,255,255,0.8), transparent 60%), radial-gradient(circle at 28% 74%, rgba(154,140,255,0.55), transparent 55%);"
+              class="project-tile"
+              href="#"
+              data-tags="ai mobile"
+              data-animate="panel"
+              aria-label="Project 02"
             >
-              <span class="project-card__rail" aria-hidden="true"></span>
-              <div class="project-card__timeline">
-                <time class="project-card__time" datetime="2023-05">2023.05</time>
-                <span class="project-card__tag">資料平台</span>
-              </div>
-              <div class="project-card__body">
-                <div class="project-card__content">
-                  <div class="project-card__header">
-                    <div class="project-card__heading">
-                      <h3 class="project-card__title">棒球資料整合平台</h3>
-                    </div>
-                    <span class="project-card__meta">4 人團隊｜Flask・Next.js・MySQL</span>
-                  </div>
-                  <p>
-                    集中中華職棒球隊、球員與賽程資訊的全端服務。使用者可 Google 登入追蹤球員、
-                    新增備註並查詢即時戰績，解決資料分散與維護成本高的問題。
-                  </p>
-                  <ul class="project-card__highlights">
-                    <li>開發 Firecrawl/Selenium 爬蟲與 Pydantic 驗證流程，確保資料品質。</li>
-                    <li>以 Flask REST API 搭配 Firebase 驗證保護端點，支援跨域存取。</li>
-                    <li>Next.js 前端提供戰績儀表與追蹤清單，強化球迷互動。</li>
-                  </ul>
-                  <span class="project-card__cta">查看完整案例</span>
-                  </div>
-                <div class="project-card__media" aria-hidden="true">
-                  <span class="project-card__thumb"></span>
-                </div>
+              <figure class="project-tile__media">
+                <img
+                  src="https://picsum.photos/seed/project-02/600/750"
+                  alt="Project 02 專案預覽圖（placeholder）"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+              <div class="project-tile__overlay">
+                <span class="project-tile__title">Project 02</span>
               </div>
             </a>
-
             <a
-              class="project-card"
+              class="project-tile"
+              href="#"
               data-tags="hardware ai"
-              id="ambient-light"
-              href="projects/ambient-light.html"
-              style="--accent: #5fe4ff; --accent-soft: rgba(95, 228, 255, 0.22); --accent-glow: rgba(95, 228, 255, 0.42); --project-image: radial-gradient(circle at 30% 30%, rgba(95,228,255,0.6), transparent 60%), radial-gradient(circle at 70% 70%, rgba(255,255,255,0.85), transparent 58%);"
+              data-animate="panel"
+              aria-label="Project 03"
             >
-              <span class="project-card__rail" aria-hidden="true"></span>
-              <div class="project-card__timeline">
-                <time class="project-card__time" datetime="2022-10">2022.10</time>
-                <span class="project-card__tag">硬體 / IoT</span>
-              </div>
-              <div class="project-card__body">
-                <div class="project-card__content">
-                  <div class="project-card__header">
-                    <div class="project-card__heading">
-                      <h3 class="project-card__title">動態背光燈光調整系統</h3>
-                    </div>
-                    <span class="project-card__meta">獨立完成｜Python・ESP8266・WS2812B</span>
-                  </div>
-                  <p>
-                    以低於市售 10% 的成本打造即時環境背光系統。透過 Python 捕捉螢幕邊緣顏色，
-                    串流至 ESP8266 控制 FastLED，將 LED 變換延遲壓縮至 16 毫秒內，顯著減少眼睛疲勞並強化沉浸感。
-                  </p>
-                  <ul class="project-card__highlights">
-                    <li>整合硬體選型、演算法與韌體開發，全程獨立完成。</li>
-                    <li>優化取樣演算法與序列通訊，達到近 60 FPS 的即時同步效果。</li>
-                    <li>以可擴充架構預留智慧家居整合與燈帶擴充可能。</li>
-                  </ul>
-                  <span class="project-card__cta">查看完整案例</span>
-                  </div>
-                <div class="project-card__media" aria-hidden="true">
-                  <span class="project-card__thumb"></span>
-                </div>
+              <figure class="project-tile__media">
+                <img
+                  src="https://picsum.photos/seed/project-03/600/750"
+                  alt="Project 03 專案預覽圖（placeholder）"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+              <div class="project-tile__overlay">
+                <span class="project-tile__title">Project 03</span>
               </div>
             </a>
-
             <a
-              class="project-card"
-              data-tags="hardware"
-              id="haptic"
-              href="projects/haptic.html"
-              style="--accent: #ffb95f; --accent-soft: rgba(255, 185, 95, 0.24); --accent-glow: rgba(255, 185, 95, 0.45); --project-image: radial-gradient(circle at 70% 32%, rgba(255,255,255,0.85), transparent 62%), radial-gradient(circle at 32% 74%, rgba(255,185,95,0.6), transparent 55%);"
-            >
-              <span class="project-card__rail" aria-hidden="true"></span>
-              <div class="project-card__timeline">
-                <time class="project-card__time" datetime="2022-06">2022.06</time>
-                <span class="project-card__tag">硬體 / XR</span>
-              </div>
-              <div class="project-card__body">
-                <div class="project-card__content">
-                  <div class="project-card__header">
-                    <div class="project-card__heading">
-                      <h3 class="project-card__title">馬達腳部觸覺回饋系統</h3>
-                    </div>
-                    <span class="project-card__meta">2 人團隊｜ESP32・Unity</span>
-                  </div>
-                  <p>
-                    開發輕量可穿戴的腳部震動裝置，與 Unity 虛擬環境即時連動，
-                    模擬砂石、草地等地面質感，增強 VR/AR 沉浸式體驗。
-                  </p>
-                  <ul class="project-card__highlights">
-                    <li>設計多點震動馬達陣列與無線通訊，精準傳遞觸覺變化。</li>
-                    <li>以人體工學與可調式綁帶確保長時間穿戴舒適。</li>
-                    <li>展示於遊戲、教育與復健場域的延伸應用潛力。</li>
-                  </ul>
-                  <span class="project-card__cta">查看完整案例</span>
-                  </div>
-                <div class="project-card__media" aria-hidden="true">
-                  <span class="project-card__thumb"></span>
-                </div>
-              </div>
-            </a>
-
-            <a
-              class="project-card"
+              class="project-tile"
+              href="#"
               data-tags="web data"
-              id="sky-pylot"
-              href="projects/sky-pylot.html"
-              style="--accent: #67c7ff; --accent-soft: rgba(103, 199, 255, 0.24); --accent-glow: rgba(103, 199, 255, 0.46); --project-image: radial-gradient(circle at 26% 30%, rgba(103,199,255,0.55), transparent 60%), radial-gradient(circle at 72% 70%, rgba(255,255,255,0.85), transparent 58%);"
+              data-animate="panel"
+              aria-label="Project 04"
             >
-              <span class="project-card__rail" aria-hidden="true"></span>
-              <div class="project-card__timeline">
-                <time class="project-card__time" datetime="2022-03">2022.03</time>
-                <span class="project-card__tag">資料整合</span>
-              </div>
-              <div class="project-card__body">
-                <div class="project-card__content">
-                  <div class="project-card__header">
-                    <div class="project-card__heading">
-                      <h3 class="project-card__title">Your Sky Pylot 天文資訊整合站</h3>
-                      <span class="project-card__badge">🏆 最佳資料應用獎</span>
-                    </div>
-                    <span class="project-card__meta">3 人團隊｜Django・Selenium・Google API</span>
-                  </div>
-                  <p>
-                    為觀星愛好者打造的一站式規劃工具，彙整天氣、天文預報、NASA 圖片與國內外新聞，
-                    讓使用者輸入地點與時間即可取得完整的觀星資訊。
-                  </p>
-                  <ul class="project-card__highlights">
-                    <li>開發爬蟲與資料處理流程，整合中央氣象局、Time and Date、NASA 等多來源。</li>
-                    <li>在結果頁呈現月相、行星升落、空氣品質與天文事件，協助行程規劃。</li>
-                    <li>規劃資料庫快取以改善首頁載入效能並提升新聞相關度。</li>
-                    <li>在校內競賽中以資料整合成效獲頒「最佳資料應用獎」。</li>
-                  </ul>
-                  <span class="project-card__cta">查看完整案例</span>
-                  </div>
-                <div class="project-card__media" aria-hidden="true">
-                  <span class="project-card__thumb"></span>
-                </div>
+              <figure class="project-tile__media">
+                <img
+                  src="https://picsum.photos/seed/project-04/600/750"
+                  alt="Project 04 專案預覽圖（placeholder）"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+              <div class="project-tile__overlay">
+                <span class="project-tile__title">Project 04</span>
               </div>
             </a>
-
             <a
-              class="project-card"
-              data-tags="game ai"
-              id="show-the-sheep"
-              href="projects/show-the-sheep.html"
-              style="--accent: #ff7f6b; --accent-soft: rgba(255, 127, 107, 0.22); --accent-glow: rgba(255, 127, 107, 0.42); --project-image: radial-gradient(circle at 70% 28%, rgba(255,255,255,0.8), transparent 60%), conic-gradient(from 160deg at 30% 70%, rgba(255,127,107,0.55), transparent 60%);"
+              class="project-tile"
+              href="#"
+              data-tags="mobile web"
+              data-animate="panel"
+              aria-label="Project 05"
             >
-              <span class="project-card__rail" aria-hidden="true"></span>
-              <div class="project-card__timeline">
-                <time class="project-card__time" datetime="2021-11">2021.11</time>
-                <span class="project-card__tag">遊戲</span>
+              <figure class="project-tile__media">
+                <img
+                  src="https://picsum.photos/seed/project-05/600/750"
+                  alt="Project 05 專案預覽圖（placeholder）"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+              <div class="project-tile__overlay">
+                <span class="project-tile__title">Project 05</span>
               </div>
-              <div class="project-card__body">
-                <div class="project-card__content">
-                  <div class="project-card__header">
-                    <div class="project-card__heading">
-                      <h3 class="project-card__title">Show the Sheep 合作型策略遊戲</h3>
-                      <span class="project-card__badge">🏆 Normal Game Jam 榮耀</span>
-                    </div>
-                    <span class="project-card__meta">Game Jam 三人團隊｜Python・Pygame</span>
-                  </div>
-                  <p>
-                    於 48 小時 Game Jam 中，以「視覺受限」為題打造雙人合作遊戲。
-                    玩家需分工操控牧羊犬與無人機，在夜間森林中護送羊群躲避狼群。
-                  </p>
-                  <ul class="project-card__highlights">
-                    <li>負責所有程式開發，實作 AI 羊群行為、動態視野與物理碰撞系統。</li>
-                    <li>遊戲獲得 Gameplay 第一名、Overall 第三名等多項佳績。</li>
-                    <li>透過動態遮罩與音效營造緊張氛圍，提升合作溝通樂趣。</li>
-                  </ul>
-                  <span class="project-card__cta">查看完整案例</span>
-                  </div>
-                <div class="project-card__media" aria-hidden="true">
-                  <span class="project-card__thumb"></span>
-                </div>
+            </a>
+            <a
+              class="project-tile"
+              href="#"
+              data-tags="game ai"
+              data-animate="panel"
+              aria-label="Project 06"
+            >
+              <figure class="project-tile__media">
+                <img
+                  src="https://picsum.photos/seed/project-06/600/750"
+                  alt="Project 06 專案預覽圖（placeholder）"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+              <div class="project-tile__overlay">
+                <span class="project-tile__title">Project 06</span>
+              </div>
+            </a>
+            <a
+              class="project-tile"
+              href="#"
+              data-tags="data ai"
+              data-animate="panel"
+              aria-label="Project 07"
+            >
+              <figure class="project-tile__media">
+                <img
+                  src="https://picsum.photos/seed/project-07/600/750"
+                  alt="Project 07 專案預覽圖（placeholder）"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+              <div class="project-tile__overlay">
+                <span class="project-tile__title">Project 07</span>
+              </div>
+            </a>
+            <a
+              class="project-tile"
+              href="#"
+              data-tags="hardware data"
+              data-animate="panel"
+              aria-label="Project 08"
+            >
+              <figure class="project-tile__media">
+                <img
+                  src="https://picsum.photos/seed/project-08/600/750"
+                  alt="Project 08 專案預覽圖（placeholder）"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+              <div class="project-tile__overlay">
+                <span class="project-tile__title">Project 08</span>
+              </div>
+            </a>
+            <a
+              class="project-tile"
+              href="#"
+              data-tags="web ai"
+              data-animate="panel"
+              aria-label="Project 09"
+            >
+              <figure class="project-tile__media">
+                <img
+                  src="https://picsum.photos/seed/project-09/600/750"
+                  alt="Project 09 專案預覽圖（placeholder）"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+              <div class="project-tile__overlay">
+                <span class="project-tile__title">Project 09</span>
+              </div>
+            </a>
+            <a
+              class="project-tile"
+              href="#"
+              data-tags="mobile game"
+              data-animate="panel"
+              aria-label="Project 10"
+            >
+              <figure class="project-tile__media">
+                <img
+                  src="https://picsum.photos/seed/project-10/600/750"
+                  alt="Project 10 專案預覽圖（placeholder）"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+              <div class="project-tile__overlay">
+                <span class="project-tile__title">Project 10</span>
+              </div>
+            </a>
+            <a
+              class="project-tile"
+              href="#"
+              data-tags="hardware web"
+              data-animate="panel"
+              aria-label="Project 11"
+            >
+              <figure class="project-tile__media">
+                <img
+                  src="https://picsum.photos/seed/project-11/600/750"
+                  alt="Project 11 專案預覽圖（placeholder）"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+              <div class="project-tile__overlay">
+                <span class="project-tile__title">Project 11</span>
+              </div>
+            </a>
+            <a
+              class="project-tile"
+              href="#"
+              data-tags="data web"
+              data-animate="panel"
+              aria-label="Project 12"
+            >
+              <figure class="project-tile__media">
+                <img
+                  src="https://picsum.photos/seed/project-12/600/750"
+                  alt="Project 12 專案預覽圖（placeholder）"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+              <div class="project-tile__overlay">
+                <span class="project-tile__title">Project 12</span>
               </div>
             </a>
           </div>
         </div>
+
       </section>
 
       <section
@@ -842,7 +497,7 @@
           </div>
           <div class="contact__actions">
             <a class="btn btn--primary" href="mailto:patrick@example.com">寄信給我</a>
-            <a class="btn btn--ghost" href="#top">回到最上方</a>
+            <a class="btn btn--ghost" href="#top" data-scroll-top>回到最上方</a>
           </div>
         </div>
       </section>

--- a/script.js
+++ b/script.js
@@ -4,7 +4,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const themeIcon = themeToggle?.querySelector(".theme-toggle__icon");
   const themeLabel = themeToggle?.querySelector(".theme-toggle__label");
   const filterButtons = document.querySelectorAll(".filter-btn");
-  const projectCards = document.querySelectorAll(".project-card");
+  const projectCards = document.querySelectorAll(".project-card, .project-tile");
   const backToTop = document.querySelector(".back-to-top");
   const currentYearEl = document.getElementById("current-year");
 
@@ -35,7 +35,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const autoAnimateGroups = [
     [".hero__stats", 120],
-    [".about-sticky__timeline", 160],
+    [".about-highlights", 150],
     [".project-timeline", 140],
     [".project-detail__main", 140],
     [".project-sidebar", 160],
@@ -222,81 +222,6 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
-  const aboutStickyLayouts = document.querySelectorAll("[data-about-sticky]");
-
-  aboutStickyLayouts.forEach((layout) => {
-    const stages = Array.from(layout.querySelectorAll("[data-about-stage]"));
-    const panels = Array.from(layout.querySelectorAll("[data-about-panel]"));
-    const mediaItems = Array.from(layout.querySelectorAll("[data-about-media]"));
-
-    if (!stages.length || !panels.length) {
-      return;
-    }
-
-    let activeId = "";
-
-    const setActiveStage = (id) => {
-      panels.forEach((panel) => {
-        const isMatch = panel.dataset.aboutPanel === id;
-        panel.classList.toggle("is-active", isMatch);
-        panel.setAttribute("aria-hidden", (!isMatch).toString());
-      });
-
-      mediaItems.forEach((item) => {
-        const isMatch = item.dataset.aboutMedia === id;
-        item.classList.toggle("is-active", isMatch);
-        item.setAttribute("aria-hidden", (!isMatch).toString());
-      });
-
-      stages.forEach((stage) => {
-        stage.classList.toggle("is-active", stage.dataset.aboutStage === id);
-      });
-    };
-
-    const updateActiveStage = () => {
-      const viewportHeight = window.innerHeight || 1;
-      const focusLine = viewportHeight * 0.45;
-      let closestStage = stages[0];
-      let smallestDistance = Number.POSITIVE_INFINITY;
-
-      stages.forEach((stage) => {
-        const rect = stage.getBoundingClientRect();
-        const midpoint = rect.top + rect.height / 2;
-        const distance = Math.abs(midpoint - focusLine);
-        if (distance < smallestDistance) {
-          smallestDistance = distance;
-          closestStage = stage;
-        }
-      });
-
-      if (!closestStage) {
-        return;
-      }
-
-      const nextId = closestStage.dataset.aboutStage || "";
-      if (nextId && nextId !== activeId) {
-        activeId = nextId;
-        setActiveStage(activeId);
-      }
-    };
-
-    let ticking = false;
-    const requestUpdate = () => {
-      if (ticking) {
-        return;
-      }
-      ticking = true;
-      requestAnimationFrame(() => {
-        ticking = false;
-        updateActiveStage();
-      });
-    };
-
-    updateActiveStage();
-    window.addEventListener("scroll", requestUpdate, { passive: true });
-    window.addEventListener("resize", requestUpdate);
-  });
-
   const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
   const storedTheme = localStorage.getItem("patrick-theme");
 
@@ -335,6 +260,19 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  const scrollTopLinks = document.querySelectorAll("[data-scroll-top]");
+
+  scrollTopLinks.forEach((link) => {
+    link.addEventListener("click", (event) => {
+      event.preventDefault();
+      scrollToTop();
+    });
+  });
+
   if (backToTop) {
     const toggleBackToTop = () => {
       const shouldShow = window.scrollY > 360;
@@ -344,9 +282,7 @@ document.addEventListener("DOMContentLoaded", () => {
     window.addEventListener("scroll", toggleBackToTop, { passive: true });
     toggleBackToTop();
 
-    backToTop.addEventListener("click", () => {
-      window.scrollTo({ top: 0, behavior: "smooth" });
-    });
+    backToTop.addEventListener("click", scrollToTop);
   }
 
   if (currentYearEl) {

--- a/styles.css
+++ b/styles.css
@@ -810,348 +810,165 @@ body::before {
   overflow: clip;
 }
 
-.about-sticky {
-  position: relative;
+.about-overview {
+  margin-top: clamp(2.4rem, 5vw, 3.6rem);
   display: grid;
-  gap: clamp(3rem, 5vw, 4.8rem);
+  gap: clamp(1.6rem, 3vw, 2.6rem);
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  align-items: start;
 }
 
-.about-sticky::before {
-  content: "";
-  position: absolute;
-  inset: -8%;
-  background: radial-gradient(circle at 20% 0%, rgba(79, 70, 229, 0.18), transparent 55%),
-    radial-gradient(circle at 80% 100%, rgba(56, 189, 248, 0.14), transparent 60%);
-  filter: blur(40px);
-  opacity: 0.6;
-  pointer-events: none;
-  z-index: -1;
-}
-
-.about-sticky__intro {
-  position: relative;
-  padding: clamp(2rem, 2vw + 1.6rem, 2.75rem) clamp(2.2rem, 3vw, 3rem);
-  border-radius: 1.9rem;
-  background: color-mix(in srgb, var(--color-surface-strong) 88%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
-  box-shadow: 0 32px 70px rgba(15, 23, 42, 0.18);
-  backdrop-filter: blur(28px);
+.about-overview__intro,
+.about-overview__facts {
+  padding: clamp(1.6rem, 3.2vw, 2.6rem);
+  border-radius: 1.8rem;
+  background: color-mix(in srgb, var(--color-surface-strong) 95%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 62%, transparent);
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.12);
   display: grid;
-  gap: 1.3rem;
-  overflow: clip;
+  gap: clamp(0.9rem, 2vw, 1.4rem);
 }
 
-.about-sticky__label {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  padding: 0.35rem 0.8rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--color-primary) 26%, transparent);
-  color: #fff;
-  font-size: 0.8rem;
-  letter-spacing: 0.12em;
+.about-overview__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  color: var(--color-primary);
   text-transform: uppercase;
 }
 
-.about-sticky__title {
+.about-overview__title {
   margin: 0;
-  font-size: clamp(2.1rem, 1.4rem + 1.8vw, 2.8rem);
+  font-size: clamp(1.65rem, 2.2vw + 1rem, 2.2rem);
+  line-height: 1.3;
 }
 
-.about-sticky__description {
+.about-overview__summary {
   margin: 0;
   color: var(--color-muted);
-  line-height: 1.8;
-  font-size: clamp(1rem, 0.92rem + 0.28vw, 1.12rem);
+  line-height: 1.75;
 }
 
-.about-sticky__facts {
+.about-overview__heading {
   margin: 0;
+  font-size: 1.1rem;
+}
+
+.about-overview__list {
+  margin: 0;
+  padding: 0;
   display: grid;
   gap: 1.2rem;
 }
 
-.about-sticky__facts div {
+.about-overview__list div {
   display: grid;
-  gap: 0.4rem;
+  gap: 0.35rem;
 }
 
-.about-sticky__facts dt {
-  font-size: 0.82rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--color-muted) 65%, transparent);
-}
-
-.about-sticky__facts dd {
-  margin: 0;
-  color: color-mix(in srgb, var(--color-text) 92%, transparent);
-  line-height: 1.65;
-  font-size: 0.98rem;
-}
-
-.about-sticky__body {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 420px);
-  grid-template-areas: "timeline pin";
-  gap: clamp(2.8rem, 6vw, 5.4rem);
-  align-items: start;
-}
-
-.about-sticky__pin {
-  grid-area: pin;
-  position: sticky;
-  top: clamp(5.6rem, 6vw, 8rem);
-  display: grid;
-  gap: clamp(1.1rem, 1.6vw, 1.8rem);
-  align-self: start;
-}
-
-.about-sticky__panels {
-  position: relative;
-  min-height: clamp(200px, 24vw, 300px);
-}
-
-.about-panel {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  gap: 1.1rem;
-  padding: 0 0.3rem;
-  opacity: 0;
-  transform: translateY(30px);
-  transition: opacity var(--transition), transform var(--transition);
-  pointer-events: none;
-}
-
-.about-panel.is-active {
-  opacity: 1;
-  transform: translateY(0);
-  pointer-events: auto;
-}
-
-.about-panel header h3 {
-  margin: 0 0 0.2rem;
-  font-size: clamp(1.35rem, 1rem + 1vw, 1.9rem);
-  line-height: 1.25;
-}
-.about-panel header p {
-  margin: 0;
-  font-size: clamp(1.02rem, 0.95rem + 0.35vw, 1.15rem);
-  line-height: 1.8;
-  color: color-mix(in srgb, var(--color-text) 94%, transparent);
-}
-
-.about-panel__list {
-  margin: 0;
-  padding-left: 1.2rem;
-  display: grid;
-  gap: 0.65rem;
-  color: color-mix(in srgb, var(--color-text) 94%, transparent);
-  line-height: 1.75;
-}
-
-.about-panel__list strong {
-  color: var(--color-primary);
-  font-weight: 700;
-}
-
-.about-sticky__media {
-  position: relative;
-  min-height: clamp(200px, 24vw, 300px);
-  margin-bottom: 0.5rem;
-  border-radius: 1.9rem;
-  background: linear-gradient(160deg, color-mix(in srgb, var(--color-surface-strong) 95%, transparent),
-      color-mix(in srgb, var(--color-primary) 18%, transparent));
-  border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
-  overflow: hidden;
-  box-shadow: 0 26px 60px rgba(15, 23, 42, 0.2);
-}
-
-.about-media__item {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  align-content: center;
-  justify-items: center;
-  gap: 1.1rem;
-  padding: clamp(2rem, 3vw, 2.8rem);
-  opacity: 0;
-  transform: translateY(40px) scale(0.96);
-  transition: opacity var(--transition), transform var(--transition);
-  color: color-mix(in srgb, var(--color-text) 96%, transparent);
-}
-
-.about-media__item.is-active {
-  opacity: 1;
-  transform: translateY(0) scale(1);
-}
-
-.about-media__icon {
-  display: grid;
-  place-items: center;
-  width: clamp(3.8rem, 3.2rem + 1.8vw, 4.4rem);
-  height: clamp(3.8rem, 3.2rem + 1.8vw, 4.4rem);
-  border-radius: 1.3rem;
-  background: linear-gradient(145deg, rgba(79, 70, 229, 0.9), rgba(236, 72, 153, 0.78));
-  font-size: clamp(1.8rem, 1.5rem + 0.8vw, 2.2rem);
-  color: #fff;
-  box-shadow: 0 18px 38px rgba(79, 70, 229, 0.32);
-}
-
-.about-media__caption {
-  margin: 0;
-  max-width: 18ch;
-  text-align: center;
-  line-height: 1.6;
-}
-
-.about-sticky__timeline {
-  grid-area: timeline;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: clamp(2rem, 4vw, 3rem);
-  padding-block: 1rem clamp(5rem, 8vw, 6rem);
-  overflow: clip;
-}
-
-.about-sticky__timeline::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: clamp(1.4rem, 2vw, 2.1rem);
-  width: 2px;
-  background: color-mix(in srgb, var(--color-border) 70%, transparent);
-}
-
-.about-stage {
-  position: relative;
-  min-height: clamp(280px, 34vh, 520px);
-  padding-left: clamp(3.5rem, 3vw + 2.6rem, 4.6rem);
-  display: grid;
-  align-content: center;
-  gap: 0.9rem;
-  color: color-mix(in srgb, var(--color-muted) 80%, transparent);
-}
-
-.about-stage::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: clamp(1.2rem, 2vw, 1.9rem);
-  width: 2px;
-  height: 100%;
-  background: linear-gradient(180deg, color-mix(in srgb, var(--color-primary) 45%, transparent), transparent 82%);
-  opacity: 0;
-  transition: opacity var(--transition);
-}
-
-.about-stage.is-active::before {
-  opacity: 1;
-}
-
-.about-stage.is-active {
-  color: color-mix(in srgb, var(--color-text) 92%, transparent);
-}
-
-.about-stage__number {
-  position: absolute;
-  top: 1.1rem;
-  left: 0;
-  transform: none;
-  font-size: 1.2rem;
+.about-overview__list dt {
   font-weight: 600;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--color-muted) 60%, transparent);
-}
-
-.about-stage.is-active .about-stage__number {
   color: var(--color-primary);
 }
 
-.about-stage__content h3 {
+.about-overview__list dd {
   margin: 0;
-  font-size: clamp(1.35rem, 1.15rem + 0.8vw, 1.8rem);
-}
-
-.about-stage__content p {
-  margin: 0;
-  max-width: 42ch;
+  color: var(--color-muted);
   line-height: 1.7;
 }
 
+.about-highlights {
+  margin-top: clamp(2.8rem, 5vw, 4.4rem);
+  display: grid;
+  gap: clamp(1.4rem, 3vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.about-card {
+  padding: clamp(1.6rem, 3vw, 2.4rem);
+  border-radius: 1.6rem;
+  background: color-mix(in srgb, var(--color-surface-strong) 96%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 58%, transparent);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 0.9rem;
+}
+
+.about-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.about-card p {
+  margin: 0;
+  color: var(--color-muted);
+  line-height: 1.75;
+}
+
+.about-card__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.about-card__list li {
+  position: relative;
+  padding-left: 1.2rem;
+  line-height: 1.7;
+  color: var(--color-muted);
+}
+
+.about-card__list li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.6rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--color-primary);
+  opacity: 0.45;
+}
+
+body.theme-dark .about-overview__intro,
+body.theme-dark .about-overview__facts,
+body.theme-dark .about-card {
+  background: color-mix(in srgb, var(--color-surface-strong) 88%, transparent);
+  border-color: color-mix(in srgb, var(--color-border) 40%, transparent);
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.45);
+}
+
 @media (max-width: 1024px) {
-  .about-sticky__body {
+  .about-overview {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-areas:
-      "pin"
-      "timeline";
-  }
-
-  .about-sticky__pin {
-    position: sticky;
-    top: clamp(5rem, 7vw, 7rem);
-  }
-
-  .about-sticky__timeline {
-    padding-top: clamp(2rem, 6vw, 3rem);
-  }
-
-  .about-sticky__timeline::before {
-    left: 1rem;
-  }
-
-  .about-stage {
-    padding-left: 3.4rem;
   }
 }
 
 @media (max-width: 720px) {
-  .section--sticky {
-    padding-block: 4.8rem 7.2rem;
+  .about-overview__intro,
+  .about-overview__facts {
+    padding: clamp(1.4rem, 4vw, 2rem);
   }
 
-  .about-sticky {
-    gap: 2.4rem;
-  }
-
-  .about-sticky__intro {
-    padding: 1.6rem 1.9rem;
-  }
-
-  .about-sticky__timeline {
-    padding-block: 1rem 6rem;
-  }
-
-  .about-stage {
-    min-height: clamp(220px, 42vh, 360px);
-  }
-
-  .about-sticky__media {
-    min-height: clamp(220px, 60vw, 320px);
+  .about-highlights {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
 @media (max-width: 560px) {
-  .about-stage {
-    min-height: clamp(200px, 38vh, 320px);
-    padding-left: 2.6rem;
+  .about-overview {
+    margin-top: 2rem;
   }
 
-  .about-stage__number {
-    font-size: 1rem;
+  .about-overview__title {
+    font-size: clamp(1.4rem, 5vw, 1.8rem);
   }
 
-  .about-sticky__timeline::before {
-    left: 0.85rem;
+  .about-card {
+    padding: clamp(1.3rem, 5vw, 1.8rem);
   }
 }
-
-
 .filter-controls {
   display: flex;
   flex-wrap: wrap;
@@ -1211,6 +1028,103 @@ body::before {
   }
 }
 
+
+.project-gallery {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: clamp(1.6rem, 3vw, 2.6rem);
+  margin-top: clamp(2.4rem, 4vw, 3.4rem);
+}
+
+.project-tile {
+  position: relative;
+  display: block;
+  aspect-ratio: 4 / 5;
+  border-radius: 1rem;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--color-surface-strong) 92%, transparent);
+  box-shadow: var(--shadow-soft);
+  transition: transform var(--transition), box-shadow var(--transition);
+  isolation: isolate;
+  color: inherit;
+  text-decoration: none;
+}
+
+.project-tile__media,
+.project-tile__media img {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.project-tile__media img {
+  object-fit: cover;
+  transition: transform var(--transition);
+  transform: scale(1.02);
+}
+
+.project-tile__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  padding: clamp(1.1rem, 2.5vw, 1.8rem);
+  background: linear-gradient(180deg, rgba(3, 7, 18, 0) 35%, rgba(3, 7, 18, 0.78) 96%);
+  color: #fff;
+  pointer-events: none;
+  transition: opacity var(--transition);
+  opacity: 0.88;
+}
+
+.project-tile__title {
+  font-size: clamp(1.1rem, 1.8vw, 1.35rem);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.project-tile:hover,
+.project-tile:focus-visible {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-hover);
+}
+
+.project-tile:hover .project-tile__media img,
+.project-tile:focus-visible .project-tile__media img {
+  transform: scale(1.08);
+}
+
+.project-tile:hover .project-tile__overlay,
+.project-tile:focus-visible .project-tile__overlay {
+  opacity: 1;
+}
+
+.project-tile:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--color-primary) 70%, transparent);
+  outline-offset: 4px;
+}
+
+@media (max-width: 1100px) {
+  .project-gallery {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 880px) {
+  .project-gallery {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .project-gallery {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .project-tile {
+    max-width: 420px;
+    margin-inline: auto;
+  }
+}
 
 .project-timeline {
   position: relative;
@@ -1575,7 +1489,8 @@ body::before {
   }
 }
 
-.project-card[data-hidden="true"] {
+.project-card[data-hidden="true"],
+.project-tile[data-hidden="true"] {
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- replace the project timeline with a 12-tile gallery wired to the existing animation stagger and filter controls
- add responsive gallery and tile styling with hover overlays and motion tweaks while keeping accessibility contrast
- extend the project filter script to include the new tile elements alongside legacy cards

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e21f1fa184832798bd1de87cdb435f