### PR TITLE
Redesign site with Apple-inspired frosted glass aesthetic

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,39 +1,37 @@
 :root {
-  --font-family: "Noto Sans TC", "Segoe UI", -apple-system, BlinkMacSystemFont,
-    "PingFang TC", "Microsoft JhengHei", sans-serif;
-  --color-bg: #f5f7fb;
-  --color-surface: rgba(255, 255, 255, 0.85);
-  --color-surface-strong: #ffffff;
-  --color-text: #1f2933;
-  --color-muted: #5f6c7b;
-  --color-primary: #4f46e5;
-  --color-primary-soft: rgba(79, 70, 229, 0.1);
-  --color-hero-primary: rgba(99, 102, 241, 0.32);
-  --color-hero-secondary: rgba(56, 189, 248, 0.28);
-  --color-hero-tertiary: rgba(236, 72, 153, 0.2);
-  --color-card-glow: rgba(129, 140, 248, 0.35);
-  --color-border: rgba(148, 163, 184, 0.4);
-  --shadow-soft: 0 16px 40px rgba(15, 23, 42, 0.12);
-  --shadow-hover: 0 20px 60px rgba(15, 23, 42, 0.18);
-  --blur: blur(18px);
+  --font-family: "Noto Sans TC", "SF Pro Display", "SF Pro Text", -apple-system,
+    BlinkMacSystemFont, "PingFang TC", "Microsoft JhengHei", sans-serif;
+  --color-bg: #f2f2f7;
+  --color-surface: rgba(255, 255, 255, 0.7);
+  --color-surface-strong: rgba(255, 255, 255, 0.9);
+  --color-surface-solid: #ffffff;
+  --color-text: #1d1d1f;
+  --color-muted: #6e6e73;
+  --color-primary: #0071e3;
+  --color-primary-soft: rgba(0, 113, 227, 0.12);
+  --color-border: rgba(22, 22, 23, 0.08);
+  --shadow-soft: 0 22px 55px rgba(17, 17, 19, 0.12);
+  --shadow-hover: 0 32px 80px rgba(17, 17, 19, 0.16);
+  --frost-blur: blur(28px);
+  --radius-large: 28px;
+  --radius-medium: 16px;
+  --radius-small: 10px;
   --transition: 220ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 body.theme-dark {
-  --color-bg: #0f172a;
-  --color-surface: rgba(15, 23, 42, 0.75);
-  --color-surface-strong: rgba(17, 24, 39, 0.92);
-  --color-text: #f8fafc;
-  --color-muted: #cbd5f5;
-  --color-primary: #818cf8;
-  --color-primary-soft: rgba(129, 140, 248, 0.12);
-  --color-hero-primary: rgba(99, 102, 241, 0.4);
-  --color-hero-secondary: rgba(14, 165, 233, 0.36);
-  --color-hero-tertiary: rgba(236, 72, 153, 0.32);
-  --color-card-glow: rgba(129, 140, 248, 0.45);
-  --color-border: rgba(148, 163, 184, 0.3);
-  --shadow-soft: 0 18px 50px rgba(6, 15, 39, 0.45);
-  --shadow-hover: 0 24px 70px rgba(6, 15, 39, 0.6);
+  --color-bg: #000000;
+  --color-surface: rgba(17, 17, 19, 0.76);
+  --color-surface-strong: rgba(28, 28, 30, 0.88);
+  --color-surface-solid: #1d1d1f;
+  --color-text: #f5f5f7;
+  --color-muted: #b1b1b6;
+  --color-primary: #66a9ff;
+  --color-primary-soft: rgba(102, 169, 255, 0.18);
+  --color-border: rgba(209, 209, 214, 0.16);
+  --shadow-soft: 0 28px 70px rgba(0, 0, 0, 0.55);
+  --shadow-hover: 0 36px 110px rgba(0, 0, 0, 0.6);
+  --frost-blur: blur(32px);
 }
 
 * {
@@ -70,11 +68,8 @@ body::before {
   content: "";
   position: fixed;
   inset: 0;
-  background: radial-gradient(circle at 5% 10%, rgba(99, 102, 241, 0.2), transparent 40%),
-    radial-gradient(circle at 95% 15%, rgba(192, 132, 252, 0.2), transparent 45%),
-    radial-gradient(circle at 50% 90%, rgba(45, 212, 191, 0.18), transparent 45%);
-  filter: var(--blur);
-  opacity: 0.8;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.7) 0%, rgba(242, 242, 247, 0.95) 40%,
+      rgba(235, 235, 240, 0.9) 100%);
   pointer-events: none;
   z-index: -2;
 }
@@ -82,13 +77,18 @@ body::before {
 .bg-accent {
   position: fixed;
   inset: 0;
-  background: linear-gradient(135deg, rgba(79, 70, 229, 0.08), rgba(236, 72, 153, 0.06));
+  background: radial-gradient(circle at 20% 10%, rgba(255, 255, 255, 0.6), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(0, 113, 227, 0.14), transparent 60%),
+    radial-gradient(circle at 90% 70%, rgba(120, 120, 128, 0.12), transparent 62%);
+  filter: var(--frost-blur);
+  opacity: 0.8;
   z-index: -3;
 }
 
 .container {
-  width: min(1100px, 92vw);
+  width: min(1160px, 92vw);
   margin: 0 auto;
+  padding-inline: clamp(1.5rem, 4vw, 3rem);
 }
 
 @keyframes float-soft {
@@ -180,8 +180,8 @@ body::before {
   position: sticky;
   top: 0;
   z-index: 10;
-  backdrop-filter: blur(18px);
-  background: color-mix(in srgb, var(--color-surface) 90%, transparent);
+  backdrop-filter: var(--frost-blur);
+  background: color-mix(in srgb, var(--color-surface) 85%, transparent);
   border-bottom: 1px solid var(--color-border);
 }
 
@@ -190,7 +190,7 @@ body::before {
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
-  padding: 0.85rem 0;
+  padding-block: 1rem;
 }
 
 .brand {
@@ -206,142 +206,84 @@ body::before {
 .brand__logo {
   display: grid;
   place-items: center;
-  width: 2.3rem;
-  height: 2.3rem;
-  border-radius: 0.9rem;
-  background: linear-gradient(135deg, var(--color-primary), #38bdf8);
-  color: white;
-  font-weight: 800;
-  font-size: 1.1rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: var(--radius-small);
+  background: color-mix(in srgb, var(--color-text) 92%, transparent);
+  color: var(--color-surface-solid);
+  font-weight: 700;
+  font-size: 1.05rem;
+  letter-spacing: 0.08em;
 }
 
 .site-nav {
   display: flex;
   align-items: center;
-  gap: 1.25rem;
+  gap: clamp(1.25rem, 3vw, 1.8rem);
   font-size: 0.95rem;
+  letter-spacing: 0.04em;
 }
 
 .site-nav a {
-  color: var(--color-muted);
+  color: color-mix(in srgb, var(--color-text) 86%, transparent);
   text-decoration: none;
-  transition: color var(--transition);
+  padding-block: 0.25rem;
+  transition: color var(--transition), border-color var(--transition);
+  border-bottom: 2px solid transparent;
 }
 
 .site-nav a:hover,
 .site-nav a:focus {
   color: var(--color-primary);
+  border-color: currentColor;
 }
 
 .theme-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4rem;
   border: 1px solid var(--color-border);
-  background: color-mix(in srgb, var(--color-surface-strong) 90%, transparent);
+  background: color-mix(in srgb, var(--color-surface-strong) 85%, transparent);
   color: inherit;
-  padding: 0.5rem 0.9rem;
+  padding: 0.45rem 0.85rem;
   border-radius: 999px;
   cursor: pointer;
-  font-size: 0.9rem;
-  transition: transform var(--transition), box-shadow var(--transition);
+  font-size: 0.85rem;
+  transition: background var(--transition), box-shadow var(--transition),
+    transform var(--transition);
 }
 
 .theme-toggle:hover,
 .theme-toggle:focus {
   transform: translateY(-1px);
-  box-shadow: var(--shadow-soft);
+  background: color-mix(in srgb, var(--color-surface-strong) 92%, transparent);
+  box-shadow: 0 12px 30px rgba(17, 17, 19, 0.12);
 }
 
 .hero {
   position: relative;
-  padding: 6.5rem 0 4rem;
-  overflow: hidden;
+  padding: clamp(5rem, 12vh, 6.5rem) 0 clamp(4rem, 10vh, 5rem);
+  overflow: visible;
 }
 
 .hero::before,
-.hero::after {
-  content: "";
-  position: absolute;
-  z-index: -3;
-  border-radius: 40% 60% 50% 70%;
-  filter: blur(0);
-  opacity: 0.85;
-  mix-blend-mode: screen;
-}
-
-.hero::before {
-  width: clamp(320px, 42vw, 520px);
-  height: clamp(320px, 42vw, 520px);
-  background: radial-gradient(circle at 30% 30%, var(--color-hero-primary), transparent 70%);
-  top: -12%;
-  left: -8%;
-  animation: float-soft 18s ease-in-out infinite;
-}
-
-.hero::after {
-  width: clamp(280px, 36vw, 460px);
-  height: clamp(280px, 36vw, 460px);
-  background: radial-gradient(circle at 70% 40%, var(--color-hero-secondary), transparent 70%),
-    radial-gradient(circle at 40% 70%, var(--color-hero-tertiary), transparent 72%);
-  bottom: -22%;
-  right: -12%;
-  animation: float-soft 22s ease-in-out infinite reverse;
-}
-
+.hero::after,
 .hero__layers {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: -2;
-  overflow: hidden;
-}
-
-.hero__layer {
-  position: absolute;
-  display: block;
-  border-radius: 50%;
-  filter: blur(0);
-  opacity: 0.8;
-  mix-blend-mode: screen;
-  will-change: transform;
-  transition: transform 0.6s ease-out;
-}
-
-.hero__layer--halo {
-  width: clamp(340px, 48vw, 580px);
-  height: clamp(340px, 48vw, 580px);
-  top: -22%;
-  right: -10%;
-  background: radial-gradient(circle at 20% 30%, rgba(79, 70, 229, 0.45), transparent 65%),
-    radial-gradient(circle at 65% 75%, rgba(236, 72, 153, 0.28), transparent 70%);
-}
-
-.hero__layer--ring {
-  width: clamp(420px, 54vw, 640px);
-  height: clamp(420px, 54vw, 640px);
-  top: 10%;
-  left: -15%;
-  border: 1px solid rgba(129, 140, 248, 0.35);
-  background: radial-gradient(circle, rgba(56, 189, 248, 0.25) 0%, transparent 72%);
-  mix-blend-mode: lighten;
-}
-
-.hero__layer--orb {
-  width: clamp(140px, 20vw, 240px);
-  height: clamp(140px, 20vw, 240px);
-  bottom: 2%;
-  right: 20%;
-  background: radial-gradient(circle at 40% 35%, rgba(45, 212, 191, 0.8), transparent 70%);
-  box-shadow: 0 35px 80px rgba(45, 212, 191, 0.25);
+  display: none;
 }
 
 .hero__content {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 3rem;
+  gap: clamp(2.4rem, 5vw, 3.5rem);
   align-items: center;
   position: relative;
+  padding: clamp(2.5rem, 6vw, 3.5rem);
+  border-radius: var(--radius-large);
+  background: color-mix(in srgb, var(--color-surface) 86%, transparent);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: var(--frost-blur);
 }
 
 .hero__text {
@@ -352,39 +294,28 @@ body::before {
 .hero__badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.55rem 1.1rem;
-  border-radius: 999px;
-  background: linear-gradient(135deg, rgba(79, 70, 229, 0.16), rgba(14, 165, 233, 0.16));
-  color: var(--color-primary);
+  gap: 0.6rem;
+  padding: 0.55rem 0.95rem;
+  border-radius: var(--radius-medium);
+  background: color-mix(in srgb, var(--color-surface-strong) 92%, transparent);
+  color: color-mix(in srgb, var(--color-text) 85%, transparent);
   font-weight: 600;
-  font-size: 0.85rem;
-  letter-spacing: 0.04em;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.1);
-  position: relative;
-  overflow: hidden;
-}
-
-.hero__badge::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(120deg, transparent 30%, rgba(255, 255, 255, 0.6) 50%, transparent 70%);
-  opacity: 0.6;
-  animation: badge-glow 4.8s ease-in-out infinite;
-  pointer-events: none;
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
 }
 
 .hero__badge span:first-child {
-  font-size: 1rem;
+  font-size: 0.95rem;
 }
 
 .hero__eyebrow {
   font-weight: 600;
-  letter-spacing: 0.18em;
-  font-size: 0.75rem;
+  letter-spacing: 0.24em;
+  font-size: 0.78rem;
   text-transform: uppercase;
-  color: var(--color-primary);
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
 }
 
 .hero__title {
@@ -395,8 +326,9 @@ body::before {
 
 .hero__description {
   color: var(--color-muted);
-  line-height: 1.7;
+  line-height: 1.65;
   margin: 0;
+  max-width: 50ch;
 }
 
 .hero__actions {
@@ -416,7 +348,7 @@ body::before {
   align-items: center;
   justify-content: center;
   padding: 0.85rem 1.7rem;
-  border-radius: 999px;
+  border-radius: var(--radius-medium);
   font-weight: 600;
   text-decoration: none;
   transition: transform var(--transition), box-shadow var(--transition),
@@ -426,30 +358,30 @@ body::before {
 .btn--primary {
   background: var(--color-primary);
   color: #fff;
-  box-shadow: var(--shadow-soft);
+  box-shadow: 0 18px 40px rgba(0, 113, 227, 0.24);
 }
 
 .btn--primary:hover,
 .btn--primary:focus {
   transform: translateY(-2px);
-  box-shadow: var(--shadow-hover);
+  box-shadow: 0 24px 55px rgba(0, 113, 227, 0.28);
 }
 
 .btn--ghost {
-  background: transparent;
-  color: var(--color-primary);
-  border: 1px solid var(--color-primary);
+  background: color-mix(in srgb, var(--color-surface) 88%, transparent);
+  color: color-mix(in srgb, var(--color-text) 85%, transparent);
+  border: 1px solid var(--color-border);
 }
 
 .btn--ghost:hover,
 .btn--ghost:focus {
-  background: var(--color-primary-soft);
+  background: color-mix(in srgb, var(--color-primary-soft) 50%, var(--color-surface));
 }
 
 .hero__stats {
   display: grid;
-  gap: 1.2rem;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: clamp(1rem, 2.5vw, 1.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   position: relative;
   z-index: 1;
 }
@@ -457,62 +389,47 @@ body::before {
 .hero__stats::before {
   content: "";
   position: absolute;
-  inset: -12% -8% -18% 10%;
-  background: linear-gradient(160deg, rgba(15, 23, 42, 0.08), transparent 55%),
-    radial-gradient(circle at 20% 30%, rgba(129, 140, 248, 0.3), transparent 65%);
-  filter: blur(60px);
-  opacity: 0.7;
+  inset: -6% -4% -10% -4%;
+  background: color-mix(in srgb, var(--color-surface) 90%, transparent);
+  border-radius: var(--radius-large);
+  border: 1px solid var(--color-border);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+  backdrop-filter: var(--frost-blur);
   z-index: -1;
-  pointer-events: none;
 }
 
 .stat-card {
   position: relative;
   display: grid;
-  gap: 0.55rem;
-  padding: 1.6rem 1.4rem;
-  border-radius: 1.2rem;
-  background: linear-gradient(150deg, color-mix(in srgb, var(--color-surface-strong) 92%, transparent),
-      color-mix(in srgb, var(--color-primary) 18%, transparent));
-  backdrop-filter: blur(14px);
-  border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
-  box-shadow: var(--shadow-soft);
-  overflow: hidden;
-  transform-origin: center;
-  transition: transform 480ms cubic-bezier(0.16, 1, 0.3, 1),
-    border-color 320ms ease, box-shadow 320ms ease;
-}
-
-.stat-card::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at top right, var(--color-card-glow), transparent 55%);
-  opacity: 0.45;
-  pointer-events: none;
-  z-index: 0;
+  gap: 0.65rem;
+  padding: 1.8rem 1.6rem;
+  border-radius: var(--radius-medium);
+  background: color-mix(in srgb, var(--color-surface-strong) 92%, transparent);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 18px 40px rgba(17, 17, 19, 0.1);
+  backdrop-filter: var(--frost-blur);
+  transition: transform 320ms cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 320ms ease;
 }
 
 .stat-card:hover,
 .stat-card:focus-visible {
-  transform: translate3d(0, -6px, 0) scale(1.02);
-  border-color: color-mix(in srgb, var(--color-primary) 30%, transparent);
-  box-shadow: var(--shadow-strong);
+  transform: translateY(-6px);
+  box-shadow: 0 28px 65px rgba(17, 17, 19, 0.16);
 }
 
 .stat-card__icon {
   position: relative;
   z-index: 1;
-  width: 2.6rem;
-  height: 2.6rem;
+  width: 2.4rem;
+  height: 2.4rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0.75rem;
-  background: linear-gradient(140deg, color-mix(in srgb, var(--color-primary) 30%, transparent),
-      color-mix(in srgb, var(--color-accent) 24%, transparent));
-  font-size: 1.45rem;
-  box-shadow: inset 0 0 12px rgba(255, 255, 255, 0.24);
+  border-radius: var(--radius-small);
+  background: rgba(0, 113, 227, 0.08);
+  color: var(--color-primary);
+  font-size: 1.35rem;
 }
 
 .stat-card__value {
@@ -551,11 +468,12 @@ body::before {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(1.4rem, 5vw, 2.3rem);
-  border-radius: 2rem;
-  background: color-mix(in srgb, var(--color-surface-strong) 92%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
-  box-shadow: 0 30px 70px rgba(15, 23, 42, 0.16);
+  padding: clamp(1.6rem, 4vw, 2.5rem);
+  border-radius: var(--radius-large);
+  background: color-mix(in srgb, var(--color-surface) 90%, transparent);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 18px 45px rgba(17, 17, 19, 0.12);
+  backdrop-filter: var(--frost-blur);
   min-height: clamp(220px, 28vw, 260px);
   width: clamp(200px, 28vw, 260px);
   isolation: isolate;
@@ -565,28 +483,28 @@ body::before {
   position: relative;
   width: 100%;
   aspect-ratio: 5 / 6;
-  border-radius: 1.6rem;
+  border-radius: var(--radius-medium);
   padding: clamp(1.2rem, 3.6vw, 1.6rem);
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
   gap: 0.6rem;
-  background: linear-gradient(150deg, rgba(79, 70, 229, 0.88), rgba(14, 165, 233, 0.82));
-  color: #f8fafc;
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.32);
+  background: linear-gradient(160deg, rgba(0, 113, 227, 0.85), rgba(0, 90, 204, 0.78));
+  color: #f5f5f7;
+  box-shadow: 0 28px 55px rgba(0, 113, 227, 0.38);
   overflow: hidden;
 }
 
 .intro__badge::after {
   content: "";
   position: absolute;
-  inset: 14% auto auto 12%;
-  width: clamp(38px, 10vw, 48px);
-  height: clamp(38px, 10vw, 48px);
-  border-radius: 1.1rem;
-  background: color-mix(in srgb, rgba(255, 255, 255, 0.82) 70%, transparent);
-  opacity: 0.3;
-  transform: rotate(-12deg);
+  inset: 12% auto auto 12%;
+  width: clamp(38px, 10vw, 46px);
+  height: clamp(38px, 10vw, 46px);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.25);
+  opacity: 0.5;
+  transform: rotate(-8deg);
 }
 
 .intro__badge-mark {
@@ -600,23 +518,15 @@ body::before {
 .intro__badge-caption {
   position: relative;
   z-index: 1;
-  font-size: 0.85rem;
-  letter-spacing: 0.22em;
+  font-size: 0.78rem;
+  letter-spacing: 0.28em;
   text-transform: uppercase;
   font-weight: 600;
-  color: color-mix(in srgb, #f8fafc 88%, transparent);
+  color: rgba(255, 255, 255, 0.75);
 }
 
 .intro__glow {
-  position: absolute;
-  inset: -12% -8%;
-  background: radial-gradient(circle at 30% 25%, rgba(255, 255, 255, 0.42), transparent 58%),
-    radial-gradient(circle at 70% 80%, rgba(129, 140, 248, 0.35), transparent 60%),
-    conic-gradient(from 120deg at 50% 20%, rgba(79, 70, 229, 0.28), transparent 70%);
-  filter: blur(36px);
-  opacity: 0.75;
-  pointer-events: none;
-  z-index: -1;
+  display: none;
 }
 
 .intro__content {
@@ -629,7 +539,7 @@ body::before {
   font-size: 0.95rem;
   letter-spacing: 0.26em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--color-muted) 72%, transparent);
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
 }
 
 .intro__title {
@@ -640,9 +550,10 @@ body::before {
 
 .intro__description {
   margin: 0;
-  color: color-mix(in srgb, var(--color-text) 92%, transparent);
+  color: color-mix(in srgb, var(--color-text) 88%, transparent);
   font-size: 1.05rem;
-  line-height: 1.78;
+  line-height: 1.7;
+  max-width: 58ch;
 }
 
 .intro__highlights {
@@ -659,10 +570,11 @@ body::before {
   align-items: center;
   gap: 0.6rem;
   padding: 0.85rem 1rem;
-  border-radius: 1.2rem;
-  background: color-mix(in srgb, var(--color-surface-strong) 90%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
+  border-radius: var(--radius-medium);
+  background: color-mix(in srgb, var(--color-surface-strong) 92%, transparent);
+  border: 1px solid var(--color-border);
   font-weight: 500;
+  backdrop-filter: var(--frost-blur);
 }
 
 .intro__highlights span {
@@ -703,14 +615,7 @@ body::before {
 }
 
 .section--soft::before {
-  content: "";
-  position: absolute;
-  inset: 6% 8%;
-  background: linear-gradient(135deg, rgba(79, 70, 229, 0.08), rgba(45, 212, 191, 0.06));
-  filter: blur(60px);
-  opacity: 0.7;
-  z-index: -1;
-  pointer-events: none;
+  content: none;
 }
 
 .section--layered {
@@ -730,55 +635,22 @@ body::before {
 }
 
 .section__float {
-  position: absolute;
-  border-radius: 999px;
-  filter: blur(0);
-  pointer-events: none;
-  opacity: 0.65;
-  mix-blend-mode: screen;
-  will-change: transform;
-  z-index: -1;
-}
-
-.section__float--about {
-  width: clamp(180px, 28vw, 260px);
-  height: clamp(180px, 28vw, 260px);
-  top: 6%;
-  right: 8%;
-  background: radial-gradient(circle at 40% 35%, rgba(192, 132, 252, 0.4), transparent 68%);
-  box-shadow: 0 30px 80px rgba(192, 132, 252, 0.25);
-}
-
-.section__float--projects {
-  width: clamp(220px, 32vw, 320px);
-  height: clamp(220px, 32vw, 320px);
-  top: -8%;
-  left: -10%;
-  background: radial-gradient(circle, rgba(59, 130, 246, 0.38), transparent 70%);
-}
-
-.section__float--contact {
-  width: clamp(200px, 30vw, 320px);
-  height: clamp(200px, 30vw, 320px);
-  bottom: -20%;
-  right: -12%;
-  background: radial-gradient(circle at 45% 40%, rgba(14, 165, 233, 0.45), transparent 70%),
-    radial-gradient(circle at 70% 65%, rgba(236, 72, 153, 0.32), transparent 75%);
+  display: none;
 }
 
 .section--accent {
   position: relative;
   overflow: hidden;
-  color: #f8faff;
+  color: var(--color-text);
 }
 
 .section--accent::before {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, rgba(79, 70, 229, 0.18), rgba(14, 165, 233, 0.16));
+  background: linear-gradient(145deg, rgba(0, 113, 227, 0.12), rgba(0, 0, 0, 0.02));
   z-index: -1;
-  opacity: 0.9;
+  opacity: 1;
   pointer-events: none;
 }
 
@@ -821,10 +693,11 @@ body::before {
 .about-overview__intro,
 .about-overview__facts {
   padding: clamp(1.6rem, 3.2vw, 2.6rem);
-  border-radius: 1.8rem;
-  background: color-mix(in srgb, var(--color-surface-strong) 95%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-border) 62%, transparent);
-  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.12);
+  border-radius: var(--radius-large);
+  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 22px 50px rgba(17, 17, 19, 0.12);
+  backdrop-filter: var(--frost-blur);
   display: grid;
   gap: clamp(0.9rem, 2vw, 1.4rem);
 }
@@ -885,10 +758,11 @@ body::before {
 
 .about-card {
   padding: clamp(1.6rem, 3vw, 2.4rem);
-  border-radius: 1.6rem;
-  background: color-mix(in srgb, var(--color-surface-strong) 96%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-border) 58%, transparent);
-  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.1);
+  border-radius: var(--radius-medium);
+  background: color-mix(in srgb, var(--color-surface-strong) 94%, transparent);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 18px 45px rgba(17, 17, 19, 0.12);
+  backdrop-filter: var(--frost-blur);
   display: grid;
   gap: 0.9rem;
 }
@@ -978,19 +852,20 @@ body.theme-dark .about-card {
   gap: 0.75rem;
   margin: 0 auto 2.8rem;
   padding: clamp(0.9rem, 2vw, 1.2rem) clamp(1rem, 3vw, 1.6rem);
-  border-radius: 1.6rem;
-  background: color-mix(in srgb, var(--color-surface-strong) 88%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
-  box-shadow: 0 24px 55px rgba(15, 23, 42, 0.14);
+  border-radius: var(--radius-large);
+  background: color-mix(in srgb, var(--color-surface) 90%, transparent);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 20px 50px rgba(17, 17, 19, 0.12);
+  backdrop-filter: var(--frost-blur);
   width: min(100%, 820px);
 }
 
 .filter-btn {
   border: 1px solid var(--color-border);
-  background: color-mix(in srgb, var(--color-surface-strong) 92%, transparent);
+  background: color-mix(in srgb, var(--color-surface-strong) 95%, transparent);
   color: inherit;
-  border-radius: 999px;
-  padding: 0.55rem 1.25rem;
+  border-radius: var(--radius-medium);
+  padding: 0.6rem 1.35rem;
   cursor: pointer;
   transition: background var(--transition), color var(--transition),
     box-shadow var(--transition), transform var(--transition);
@@ -1000,7 +875,7 @@ body.theme-dark .about-card {
 .filter-btn.is-active {
   background: var(--color-primary);
   color: #fff;
-  box-shadow: var(--shadow-soft);
+  box-shadow: 0 18px 42px rgba(0, 113, 227, 0.35);
 }
 
 .filter-btn:hover,
@@ -1046,7 +921,7 @@ body.theme-dark .about-card {
   bottom: 0;
   left: clamp(1.4rem, 4.2vw, 2.2rem);
   width: 2px;
-  background: linear-gradient(180deg, rgba(129, 140, 248, 0.65), rgba(56, 189, 248, 0.28));
+  background: color-mix(in srgb, var(--color-border) 70%, transparent);
   border-radius: 999px;
   pointer-events: none;
   z-index: 0;
@@ -1062,10 +937,11 @@ body.theme-dark .about-card {
   gap: clamp(1.6rem, 4vw, 2.8rem);
   padding: clamp(1.9rem, 4vw, 2.6rem) clamp(2rem, 5vw, 3rem);
   padding-left: clamp(3.4rem, 8vw, 4.6rem);
-  border-radius: 1.9rem;
-  background: color-mix(in srgb, var(--color-surface-strong) 95%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
-  box-shadow: 0 28px 70px rgba(15, 23, 42, 0.18);
+  border-radius: var(--radius-large);
+  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 24px 60px rgba(17, 17, 19, 0.14);
+  backdrop-filter: var(--frost-blur);
   text-decoration: none;
   color: inherit;
   transition: transform var(--transition), box-shadow var(--transition),
@@ -1077,56 +953,17 @@ body.theme-dark .about-card {
   scroll-margin-block: clamp(4.5rem, 12vw, 6.5rem);
 }
 
-.project-card::before {
-  content: "";
-  position: absolute;
-  inset: -1px;
-  border-radius: inherit;
-  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 60%, rgba(255, 255, 255, 0.2)),
-      transparent 70%);
-  opacity: 0;
-  transition: opacity var(--transition);
-  z-index: 0;
-}
-
-@keyframes card-glow {
-  0% {
-    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
-  }
-  55% {
-    box-shadow: 0 28px 70px color-mix(in srgb, var(--accent) 45%, rgba(15, 23, 42, 0.18));
-  }
-  100% {
-    box-shadow: 0 25px 60px rgba(15, 23, 42, 0.16);
-  }
-}
-
-.project-card.is-visible {
-  animation: card-glow 1.3s ease-out both;
-}
-
+.project-card::before,
 .project-card::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: linear-gradient(150deg, rgba(255, 255, 255, 0.16), transparent 65%);
-  opacity: 0.32;
-  pointer-events: none;
-  z-index: 0;
+  content: none;
 }
 
 
 .project-card:hover,
 .project-card:focus-visible {
-  transform: translate3d(0, -6px, 0);
-  box-shadow: var(--shadow-hover);
-  border-color: color-mix(in srgb, var(--accent) 40%, var(--color-border));
-}
-
-.project-card:hover::before,
-.project-card:focus-visible::before {
-  opacity: 1;
+  transform: translate3d(0, -8px, 0);
+  box-shadow: 0 32px 80px rgba(17, 17, 19, 0.18);
+  border-color: color-mix(in srgb, var(--accent) 30%, var(--color-border));
 }
 
 .project-card:focus-visible {
@@ -1139,8 +976,8 @@ body.theme-dark .about-card {
   top: clamp(0.8rem, 2vw, 1.4rem);
   bottom: clamp(0.8rem, 2vw, 1.4rem);
   width: 2px;
-  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 50%, transparent), transparent);
-  opacity: 0.6;
+  background: color-mix(in srgb, var(--color-border) 70%, transparent);
+  opacity: 0.5;
   pointer-events: none;
   z-index: -1;
 }
@@ -1163,9 +1000,9 @@ body.theme-dark .about-card {
   top: 0.25rem;
   width: 0.9rem;
   height: 0.9rem;
-  border-radius: 50%;
-  background: var(--accent);
-  box-shadow: 0 0 0 6px color-mix(in srgb, var(--accent) 35%, transparent);
+  border-radius: var(--radius-small);
+  background: color-mix(in srgb, var(--accent) 80%, var(--color-surface-solid));
+  box-shadow: 0 0 0 1px var(--color-border);
 }
 
 .project-card__timeline::after {
@@ -1175,8 +1012,8 @@ body.theme-dark .about-card {
   top: 1.2rem;
   width: clamp(1.3rem, 3vw, 1.9rem);
   height: 2px;
-  background: linear-gradient(90deg, var(--accent), transparent);
-  opacity: 0.6;
+  background: color-mix(in srgb, var(--color-border) 70%, transparent);
+  opacity: 0.7;
 }
 
 .project-card__time {
@@ -1227,13 +1064,12 @@ body.theme-dark .about-card {
   align-items: center;
   gap: 0.3rem;
   padding: 0.28rem 0.7rem;
-  border-radius: 999px;
+  border-radius: var(--radius-small);
   background: color-mix(in srgb, var(--accent) 20%, var(--color-surface-strong) 80%);
   color: color-mix(in srgb, var(--accent) 80%, var(--color-text));
   font-size: 0.82rem;
   font-weight: 700;
   letter-spacing: 0.04em;
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
   white-space: nowrap;
 }
 
@@ -1280,22 +1116,22 @@ body.theme-dark .about-card {
   transform: translateX(4px);
 }
 
+
 .project-card__media {
   position: relative;
-  border-radius: 1.4rem;
-  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  border-radius: var(--radius-medium);
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
   overflow: hidden;
   min-height: clamp(200px, 24vw, 260px);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 25%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
 .project-card__thumb {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: var(--project-image, radial-gradient(circle at 30% 30%, rgba(79, 70, 229, 0.45), transparent 60%),
-      radial-gradient(circle at 70% 70%, rgba(79, 70, 229, 0.35), transparent 58%));
-  filter: saturate(115%) contrast(102%);
+  background: var(--project-image, linear-gradient(135deg, rgba(0, 113, 227, 0.35), rgba(0, 113, 227, 0.05)));
+  filter: saturate(108%) contrast(102%);
   transition: transform 0.7s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
@@ -1348,7 +1184,7 @@ body.theme-dark .about-card {
   .project-card__timeline::before {
     top: 50%;
     transform: translateY(-50%);
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 28%, transparent);
+    box-shadow: 0 0 0 1px var(--color-border);
   }
 
   .project-card__timeline::after {
@@ -1414,15 +1250,15 @@ body.theme-dark .about-card {
 }
 
 .section--accent .section__eyebrow {
-  color: rgba(255, 255, 255, 0.7);
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
 }
 
 .section--accent .section__title {
-  color: #fff;
+  color: var(--color-text);
 }
 
 .section--accent .section__subtitle {
-  color: rgba(255, 255, 255, 0.82);
+  color: var(--color-muted);
 }
 
 .contact__actions {
@@ -1434,19 +1270,18 @@ body.theme-dark .about-card {
 }
 
 .section--accent .btn--primary {
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.2);
+  box-shadow: 0 24px 60px rgba(0, 113, 227, 0.26);
 }
 
 .section--accent .btn--ghost {
-  background: rgba(255, 255, 255, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.35);
-  color: #fff;
+  background: color-mix(in srgb, var(--color-surface) 88%, transparent);
+  border: 1px solid var(--color-border);
+  color: color-mix(in srgb, var(--color-text) 85%, transparent);
 }
 
 .section--accent .btn--ghost:hover,
 .section--accent .btn--ghost:focus {
-  background: rgba(255, 255, 255, 0.18);
-  border-color: rgba(255, 255, 255, 0.5);
+  background: color-mix(in srgb, var(--color-primary-soft) 40%, var(--color-surface));
 }
 
 .site-footer {
@@ -1459,17 +1294,17 @@ body.theme-dark .about-card {
   position: fixed;
   right: 1.5rem;
   bottom: 1.5rem;
-  width: 3rem;
-  height: 3rem;
-  border-radius: 999px;
-  border: none;
-  background: linear-gradient(135deg, var(--color-primary), #22d3ee);
-  color: #fff;
+  width: 3.2rem;
+  height: 3.2rem;
+  border-radius: var(--radius-medium);
+  border: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-surface-strong) 90%, transparent);
+  color: var(--color-text);
   display: grid;
   place-items: center;
   font-size: 1.2rem;
   cursor: pointer;
-  box-shadow: var(--shadow-soft);
+  box-shadow: 0 18px 45px rgba(17, 17, 19, 0.14);
   opacity: 0;
   visibility: hidden;
   transform: translateY(20px);
@@ -1483,6 +1318,13 @@ body.theme-dark .about-card {
   transform: translateY(0);
 }
 
+.back-to-top:hover,
+.back-to-top:focus-visible {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: transparent;
+}
+
 .project-hero {
   padding-top: clamp(4rem, 8vw, 6rem);
   position: relative;
@@ -1493,10 +1335,10 @@ body.theme-dark .about-card {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(160deg, rgba(79, 70, 229, 0.14), transparent 55%),
-    radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.2), transparent 65%);
+  background: linear-gradient(160deg, rgba(0, 113, 227, 0.12), transparent 55%),
+    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.55), transparent 65%);
   z-index: -1;
-  opacity: 0.85;
+  opacity: 0.9;
   pointer-events: none;
 }
 
@@ -1552,12 +1394,14 @@ body.theme-dark .about-card {
 }
 
 .project-hero__tags li {
-  background: color-mix(in srgb, var(--color-primary) 16%, transparent);
-  color: color-mix(in srgb, var(--color-primary) 80%, #fff);
+  background: color-mix(in srgb, var(--color-surface) 90%, transparent);
+  color: color-mix(in srgb, var(--color-text) 85%, transparent);
   padding: 0.35rem 0.8rem;
-  border-radius: 999px;
+  border-radius: var(--radius-small);
+  border: 1px solid var(--color-border);
   font-size: 0.9rem;
   font-weight: 600;
+  backdrop-filter: var(--frost-blur);
 }
 
 .project-detail {
@@ -1570,7 +1414,7 @@ body.theme-dark .about-card {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(140deg, rgba(148, 163, 184, 0.12), transparent 55%);
+  background: linear-gradient(140deg, rgba(0, 0, 0, 0.04), transparent 55%);
   z-index: -1;
   pointer-events: none;
 }
@@ -1620,13 +1464,14 @@ body.theme-dark .about-card {
 .info-card {
   position: relative;
   padding: 1.8rem;
-  border-radius: 1.25rem;
+  border-radius: var(--radius-medium);
   background: color-mix(in srgb, var(--color-surface-strong) 94%, transparent);
   border: 1px solid var(--color-border);
-  box-shadow: var(--shadow-soft);
+  box-shadow: 0 20px 50px rgba(17, 17, 19, 0.14);
   display: grid;
   gap: 1rem;
   overflow: hidden;
+  backdrop-filter: var(--frost-blur);
 }
 
 .info-card > * {
@@ -1635,13 +1480,7 @@ body.theme-dark .about-card {
 }
 
 .info-card::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: radial-gradient(circle at top left, rgba(129, 140, 248, 0.24), transparent 60%);
-  opacity: 0.55;
-  pointer-events: none;
+  display: none;
 }
 
 .info-card h3 {
@@ -1693,8 +1532,8 @@ body.theme-dark .about-card {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(79, 70, 229, 0.16), rgba(236, 72, 153, 0.14));
-  opacity: 0.9;
+  background: linear-gradient(135deg, rgba(0, 113, 227, 0.15), rgba(0, 0, 0, 0.04));
+  opacity: 0.85;
   z-index: 0;
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- replace the global palette with Apple-inspired neutrals, glass blur variables, and a soft gradient backdrop
- refresh the header, hero, buttons, and intro highlights with squared geometry and frosted glass panels
- restyle project and info cards into minimalist glass tiles with subtle accents and consistent right-angled layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e29b7af4988327b70fc0b64c5e446d