### PR TITLE
Rework About section layout and stabilize mobile portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,79 +91,103 @@
               從地球科學出發，我把資料分析、互動設計與工程實作串在一起。以下用簡潔的段落介紹背景、研究、獲獎與帶隊經驗。
             </p>
           </div>
-          <div class="about-overview">
-            <div class="about-overview__intro" data-animate="fade-up">
-              <p class="about-overview__eyebrow">Profile</p>
-              <h3 class="about-overview__title">跨越地球科學與資訊工程的產品創造者</h3>
-              <p class="about-overview__summary">
-                我在國立臺灣師範大學主修地球科學並雙主修資訊工程，從專題研究、資料分析到互動產品開發一路親自實作。
-                外向實事求是的個性讓我擅長協調跨領域團隊，把複雜需求拆解成可以驗證的成果。
-              </p>
-            </div>
-            <div class="about-overview__facts" data-animate="fade-up">
-              <h4 class="about-overview__heading">背景速記</h4>
-              <dl class="about-overview__list">
-                <div>
-                  <dt>教育</dt>
-                  <dd>國立臺灣師範大學 地球科學系<br />雙主修資訊工程（2021.09 – 現在）</dd>
-                </div>
-                <div>
-                  <dt>研究領域</dt>
-                  <dd>資料分析、ML 模型壓縮、沉浸式互動系統、跨裝置體驗設計</dd>
-                </div>
-              </dl>
-            </div>
-          </div>
-          <div class="about-highlights" data-animate-group data-animate-interval="160">
-            <article class="about-card" data-animate="fade-up">
-              <h3 class="about-card__title">個人簡介</h3>
-              <p>
-                我熱愛把研究成果轉化為實際應用，自大二起持續投入跨領域專題。開朗外向且善於表達，喜歡帶著團隊一起把想法落實，
-                確保每一步都有數據與故事支撐。
-              </p>
+          <div class="about-list" data-animate-group data-animate-interval="150">
+            <article class="about-item about-item--full" data-animate="fade-up">
+              <header class="about-item__header">
+                <p class="about-item__eyebrow">Profile</p>
+                <h3 class="about-item__title">跨越地球科學與資訊工程的產品創造者</h3>
+              </header>
             </article>
-            <article class="about-card" data-animate="fade-up">
-              <h3 class="about-card__title">專題研究</h3>
-              <ul class="about-card__list">
-                <li>
-                  <strong>颱風對海洋表層葉綠素 a 影響之研究｜2018.09 – 2021.10</strong><br />
-                  以 MATLAB 分析西北太平洋颱風對藻類數量的影響，獲「美國氣象學會獎」。
-                </li>
-                <li>
-                  <strong>Model Selection: Trade-Offs Between Model Size and Predictive Accuracy｜2023.10 – 2024.01</strong><br />
-                  探討模型大小與準確率的平衡，透過超參數調整提升小型模型表現。
-                </li>
-              </ul>
+            <article class="about-item" data-animate="fade-up">
+              <header class="about-item__header">
+                <h3 class="about-item__title">背景速記</h3>
+              </header>
+              <div class="about-item__body">
+                <dl class="about-item__facts">
+                  <div class="about-item__fact">
+                    <dt>教育</dt>
+                    <dd>國立臺灣師範大學 地球科學系／雙主修資訊工程（2021.09 – 現在）</dd>
+                  </div>
+                  <div class="about-item__fact">
+                    <dt>研究領域</dt>
+                    <dd>資料分析、ML 模型壓縮、沉浸式互動系統、跨裝置體驗設計</dd>
+                  </div>
+                </dl>
+              </div>
             </article>
-            <article class="about-card" data-animate="fade-up">
-              <h3 class="about-card__title">競賽與獲獎</h3>
-              <ul class="about-card__list">
-                <li>OpenHCI 2024 人機互動工作坊 <strong>最佳 Demo 獎</strong>（ME_NU 菜單推薦系統）。</li>
-                <li>Normal Game Jam 2024 <strong>Gameplay 第一名、Overall 第三名</strong>（Show the Sheep）。</li>
-                <li>師大地科五育獎學金連續 <strong>5</strong> 次獲獎（2022.01 – 2023.09）。</li>
-              </ul>
+            <article class="about-item" data-animate="fade-up">
+              <header class="about-item__header">
+                <h3 class="about-item__title">個人簡介</h3>
+              </header>
+              <div class="about-item__body">
+                <p>
+                  我熱愛把研究成果轉化為實際應用，自大二起持續投入跨領域專題。開朗外向且善於表達，喜歡帶著團隊一起把想法落實，
+                  確保每一步都有數據與故事支撐。
+                </p>
+              </div>
             </article>
-            <article class="about-card" data-animate="fade-up">
-              <h3 class="about-card__title">工作經驗</h3>
-              <ul class="about-card__list">
-                <li>國立臺灣師範大學智慧運算導向永續發展研究中心 網頁維護總負責人（2023.09 – 現在）。</li>
-                <li>國立臺灣師範大學地球科學系 網頁維護總負責人（2023.02 – 現在）。</li>
-                <li>攜曦程式推廣學會 Python 課程助教（2021.09 – 2021.12）。</li>
-              </ul>
+            <article class="about-item" data-animate="fade-up">
+              <header class="about-item__header">
+                <h3 class="about-item__title">專題研究</h3>
+              </header>
+              <div class="about-item__body">
+                <ul class="about-item__list">
+                  <li>
+                    <strong>颱風對海洋表層葉綠素 a 影響之研究｜2018.09 – 2021.10</strong><br />
+                    以 MATLAB 分析西北太平洋颱風對藻類數量的影響，獲「美國氣象學會獎」。
+                  </li>
+                  <li>
+                    <strong>Model Selection: Trade-Offs Between Model Size and Predictive Accuracy｜2023.10 – 2024.01</strong><br />
+                    探討模型大小與準確率的平衡，透過超參數調整提升小型模型表現。
+                  </li>
+                </ul>
+              </div>
             </article>
-            <article class="about-card" data-animate="fade-up">
-              <h3 class="about-card__title">專案亮點</h3>
-              <ul class="about-card__list">
-                <li>動態背光調光系統自行設計硬體與韌體，將成本降至市售方案的 10%。</li>
-                <li>Your Sky Pylot 平台整合多來源資料並提供互動儀表，讓使用者快速掌握觀星條件。</li>
-              </ul>
+            <article class="about-item" data-animate="fade-up">
+              <header class="about-item__header">
+                <h3 class="about-item__title">競賽與獲獎</h3>
+              </header>
+              <div class="about-item__body">
+                <ul class="about-item__list">
+                  <li>OpenHCI 2024 人機互動工作坊 <strong>最佳 Demo 獎</strong>（ME_NU 菜單推薦系統）。</li>
+                  <li>Normal Game Jam 2024 <strong>Gameplay 第一名、Overall 第三名</strong>（Show the Sheep）。</li>
+                  <li>師大地科五育獎學金連續 <strong>5</strong> 次獲獎（2022.01 – 2023.09）。</li>
+                </ul>
+              </div>
             </article>
-            <article class="about-card" data-animate="fade-up">
-              <h3 class="about-card__title">社團與領導</h3>
-              <ul class="about-card__list">
-                <li>國立臺灣大學慈幼山地服務團利稻家 帶隊總召（2021.09 – 2021.12），領導 30 人籌辦 9 天營隊。</li>
-                <li>師大地科展 2023 總召（2021.09 – 2021.12），與 Open House 合作規劃科普活動。</li>
-              </ul>
+            <article class="about-item" data-animate="fade-up">
+              <header class="about-item__header">
+                <h3 class="about-item__title">工作經驗</h3>
+              </header>
+              <div class="about-item__body">
+                <ul class="about-item__list">
+                  <li>國立臺灣師範大學智慧運算導向永續發展研究中心 網頁維護總負責人（2023.09 – 現在）。</li>
+                  <li>國立臺灣師範大學地球科學系 網頁維護總負責人（2023.02 – 現在）。</li>
+                  <li>攜曦程式推廣學會 Python 課程助教（2021.09 – 2021.12）。</li>
+                </ul>
+              </div>
+            </article>
+            <article class="about-item" data-animate="fade-up">
+              <header class="about-item__header">
+                <h3 class="about-item__title">專案亮點</h3>
+              </header>
+              <div class="about-item__body">
+                <ul class="about-item__list">
+                  <li>動態背光調光系統自行設計硬體與韌體，將成本降至市售方案的 10%。</li>
+                  <li>Your Sky Pylot 平台整合多來源資料並提供互動儀表，讓使用者快速掌握觀星條件。</li>
+                </ul>
+              </div>
+            </article>
+            <article class="about-item" data-animate="fade-up">
+              <header class="about-item__header">
+                <h3 class="about-item__title">社團與領導</h3>
+              </header>
+              <div class="about-item__body">
+                <ul class="about-item__list">
+                  <li>國立臺灣大學慈幼山地服務團利稻家 帶隊總召（2021.09 – 2021.12），領導 30 人籌辦 9 天營隊。</li>
+                  <li>師大地科展 2023 總召（2021.09 – 2021.12）， Open House 合作規劃科普活動。</li>
+                </ul>
+              </div>
             </article>
           </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -31,7 +31,7 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   const autoAnimateGroups = [
-    [".about-highlights", 150],
+    [".about-list", 150],
     [".project-timeline", 140],
     [".project-detail__main", 140],
     [".project-sidebar", 160],

--- a/styles.css
+++ b/styles.css
@@ -567,6 +567,15 @@ body::before {
   margin-top: 0.9rem;
   color: var(--color-muted);
   line-height: 1.7;
+  word-break: keep-all;
+}
+
+.section--soft .section__header {
+  max-width: none;
+}
+
+.section--soft .section__subtitle {
+  max-width: 100%;
 }
 
 .section--sticky {
@@ -574,167 +583,187 @@ body::before {
   overflow: clip;
 }
 
-.about-overview {
-  margin-top: clamp(2.4rem, 5vw, 3.6rem);
-  display: grid;
-  gap: clamp(1.6rem, 3vw, 2.6rem);
-  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
-  align-items: start;
-}
-
-.about-overview__intro,
-.about-overview__facts {
-  padding: clamp(1.6rem, 3.2vw, 2.6rem);
+.about-list {
+  margin-top: clamp(2.4rem, 5vw, 3.8rem);
   border-radius: var(--radius-large);
-  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
-  border: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-surface-strong) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 85%, transparent);
   box-shadow: 0 22px 50px rgba(17, 17, 19, 0.12);
-  backdrop-filter: var(--frost-blur);
-  display: grid;
-  gap: clamp(0.9rem, 2vw, 1.4rem);
+  overflow: hidden;
 }
 
-.about-overview__eyebrow {
-  font-size: 0.75rem;
-  letter-spacing: 0.18em;
+.about-item {
+  display: grid;
+  grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
+  gap: clamp(1.2rem, 3vw, 2.6rem);
+  padding: clamp(1.6rem, 3vw, 2.6rem) clamp(1.8rem, 4vw, 3rem);
+  align-items: start;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+}
+
+.about-item--full {
+  grid-template-columns: minmax(0, 1fr);
+  gap: clamp(0.9rem, 2.2vw, 1.8rem);
+  text-align: center;
+}
+
+.about-item--full .about-item__header {
+  flex-direction: row;
+  justify-content: center;
+  align-items: baseline;
+  gap: clamp(0.9rem, 2vw, 1.6rem);
+}
+
+.about-item--full .about-item__eyebrow {
+  order: -1;
+  font-size: clamp(0.78rem, 0.4vw + 0.7rem, 0.95rem);
+  letter-spacing: 0.26em;
+}
+
+.about-item--full .about-item__title {
+  font-size: clamp(1.6rem, 1.8vw + 1.2rem, 2.4rem);
+}
+
+.about-item:last-child {
+  border-bottom: none;
+}
+
+.about-item__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  position: relative;
+}
+
+.about-item__eyebrow {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
   color: var(--color-primary);
   text-transform: uppercase;
 }
 
-.about-overview__title {
+.about-item__title {
   margin: 0;
-  font-size: clamp(1.65rem, 2.2vw + 1rem, 2.2rem);
-  line-height: 1.3;
+  font-size: clamp(1.35rem, 1.1vw + 1.2rem, 2rem);
+  line-height: 1.35;
 }
 
-.about-overview__summary {
-  margin: 0;
-  color: var(--color-muted);
-  line-height: 1.75;
+.about-item__body {
+  display: grid;
+  gap: clamp(0.8rem, 2vw, 1.4rem);
+  color: var(--color-text);
+  font-size: clamp(1.02rem, 0.6vw + 0.95rem, 1.2rem);
+  line-height: 1.7;
 }
 
-.about-overview__heading {
+.about-item__body p {
   margin: 0;
-  font-size: 1.1rem;
 }
 
-.about-overview__list {
+.about-item__facts {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 1.2rem;
+  gap: clamp(0.8rem, 2vw, 1.2rem);
 }
 
-.about-overview__list div {
+.about-item__fact {
   display: grid;
   gap: 0.35rem;
 }
 
-.about-overview__list dt {
+.about-item__fact dt {
   font-weight: 600;
   color: var(--color-primary);
 }
 
-.about-overview__list dd {
+.about-item__fact dd {
   margin: 0;
-  color: var(--color-muted);
-  line-height: 1.7;
 }
 
-.about-highlights {
-  margin-top: clamp(2.8rem, 5vw, 4.4rem);
-  display: grid;
-  gap: clamp(1.4rem, 3vw, 2rem);
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
-.about-card {
-  padding: clamp(1.6rem, 3vw, 2.4rem);
-  border-radius: var(--radius-medium);
-  background: color-mix(in srgb, var(--color-surface-strong) 94%, transparent);
-  border: 1px solid var(--color-border);
-  box-shadow: 0 18px 45px rgba(17, 17, 19, 0.12);
-  backdrop-filter: var(--frost-blur);
-  display: grid;
-  gap: 0.9rem;
-}
-
-.about-card__title {
-  margin: 0;
-  font-size: 1.1rem;
-}
-
-.about-card p {
-  margin: 0;
-  color: var(--color-muted);
-  line-height: 1.75;
-}
-
-.about-card__list {
+.about-item__list {
   margin: 0;
   padding: 0;
   list-style: none;
   display: grid;
-  gap: 0.85rem;
+  gap: clamp(0.7rem, 1.6vw, 1.1rem);
 }
 
-.about-card__list li {
+.about-item__list li {
   position: relative;
-  padding-left: 1.2rem;
-  line-height: 1.7;
-  color: var(--color-muted);
+  padding-left: 1.25rem;
 }
 
-.about-card__list li::before {
+.about-item__list li::before {
   content: "";
   position: absolute;
   left: 0;
-  top: 0.6rem;
+  top: 0.55rem;
   width: 0.5rem;
   height: 0.5rem;
   border-radius: 50%;
   background: var(--color-primary);
-  opacity: 0.45;
+  opacity: 0.5;
 }
 
-body.theme-dark .about-overview__intro,
-body.theme-dark .about-overview__facts,
-body.theme-dark .about-card {
+.about-item strong {
+  color: var(--color-text);
+}
+
+@media (max-width: 880px) {
+  .about-item {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1rem;
+  }
+
+  .about-item--full {
+    text-align: left;
+  }
+
+  .about-item--full .about-item__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.45rem;
+  }
+
+  .about-item__header {
+    padding-bottom: 0.3rem;
+    border-bottom: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
+  }
+
+  .about-item__body {
+    padding-top: 0.5rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .about-list {
+    margin-top: 2.1rem;
+    border-radius: 1.8rem;
+  }
+
+  .about-item {
+    padding: clamp(1.4rem, 5vw, 1.9rem) clamp(1.3rem, 6vw, 2rem);
+  }
+
+  .about-item__title {
+    font-size: clamp(1.25rem, 4.2vw, 1.65rem);
+  }
+
+  .about-item__body {
+    font-size: clamp(1.02rem, 4vw, 1.12rem);
+  }
+
+  .section__subtitle {
+    word-break: normal;
+  }
+}
+
+body.theme-dark .about-list {
   background: color-mix(in srgb, var(--color-surface-strong) 88%, transparent);
   border-color: color-mix(in srgb, var(--color-border) 40%, transparent);
   box-shadow: 0 18px 40px rgba(2, 6, 23, 0.45);
-}
-
-@media (max-width: 1024px) {
-  .about-overview {
-    grid-template-columns: minmax(0, 1fr);
-  }
-}
-
-@media (max-width: 720px) {
-  .about-overview__intro,
-  .about-overview__facts {
-    padding: clamp(1.4rem, 4vw, 2rem);
-  }
-}
-
-  .about-highlights {
-    grid-template-columns: minmax(0, 1fr);
-  }
-}
-
-@media (max-width: 560px) {
-  .about-overview {
-    margin-top: 2rem;
-  }
-
-  .about-overview__title {
-    font-size: clamp(1.4rem, 5vw, 1.8rem);
-  }
-
-  .about-card {
-    padding: clamp(1.3rem, 5vw, 1.8rem);
-  }
 }
 .filter-controls {
   display: flex;
@@ -1049,7 +1078,7 @@ body.theme-dark .about-card {
 
 @media (max-width: 720px) {
   .project-timeline {
-    padding-left: clamp(2.2rem, 8vw, 3.2rem);
+    padding-left: clamp(1.8rem, 7vw, 2.6rem);
     gap: clamp(2.1rem, 7vw, 2.9rem);
   }
 
@@ -1060,7 +1089,7 @@ body.theme-dark .about-card {
   .project-card {
     gap: clamp(1.1rem, 5vw, 1.7rem);
     padding: clamp(1.5rem, 6vw, 2rem) clamp(1.4rem, 6vw, 2rem);
-    padding-left: clamp(2.4rem, 9vw, 3rem);
+    padding-left: clamp(2rem, 8vw, 2.6rem);
   }
 
   .project-card__rail {
@@ -1094,8 +1123,8 @@ body.theme-dark .about-card {
 
 @media (max-width: 540px) {
   .project-card {
-    padding: clamp(1.4rem, 6.5vw, 1.8rem) clamp(1.2rem, 6vw, 1.6rem);
-    padding-left: clamp(2rem, 8vw, 2.6rem);
+    padding: clamp(1.3rem, 6.5vw, 1.7rem) clamp(1.1rem, 6vw, 1.5rem);
+    padding-left: clamp(1.4rem, 6.5vw, 1.8rem);
     border-radius: 1.6rem;
     gap: clamp(1rem, 5.5vw, 1.4rem);
   }
@@ -1118,6 +1147,34 @@ body.theme-dark .about-card {
 
   .project-card__highlights {
     gap: 0.5rem;
+  }
+
+  .project-timeline {
+    padding-left: 0;
+    gap: clamp(1.8rem, 8vw, 2.4rem);
+  }
+
+  .project-timeline::before {
+    display: none;
+  }
+
+  .project-card__rail {
+    display: none;
+  }
+
+  .project-card__timeline {
+    padding-left: 0;
+    justify-content: flex-start;
+    gap: 0.55rem;
+  }
+
+  .project-card__timeline::before {
+    position: static;
+    transform: none;
+    margin-right: 0.4rem;
+    width: 0.65rem;
+    height: 0.65rem;
+    box-shadow: none;
   }
 }
 
@@ -1460,6 +1517,15 @@ body.theme-dark .about-card {
 
 @media (max-width: 768px) {
   .site-nav {
+    display: none;
+  }
+
+  .theme-toggle {
+    padding: 0.45rem 0.6rem;
+    border-radius: 999px;
+  }
+
+  .theme-toggle__label {
     display: none;
   }
 


### PR DESCRIPTION
## Summary
- replace the About mosaic with a horizontal about-list that keeps the copy while presenting it in readable two-column rows
- drop the mosaic enhancer script and adjust styles so the portfolio timeline stays tight on small screens
- simplify the mobile header by hiding the quick navigation and shrinking the theme toggle label
- let the About profile banner span the full width, remove the redundant paragraph copy, and keep the subtitle on a single clean line

## Testing
- Manual QA - `python3 -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_68e2d3b07a6483278a73ed1d76296d42